### PR TITLE
fix: missing ca-certs and dockerization

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body>
+      <body suppressHydrationWarning>
         <SWRProvider>
           <ThemeProvider
             attribute="class"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19935,24 +19935,6 @@
         }
       }
     },
-    "node_modules/vite-node/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/vitest": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -20682,24 +20664,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/vm-browserify": {

--- a/server/assets/router.go
+++ b/server/assets/router.go
@@ -24,6 +24,5 @@ func Router(r *gin.Engine) {
 	r.POST("/assets", uploadAsset)
 
 	// Admin can see tmp files too
-	r.Static("/assets/tmp", "./assets/tmp" )
-
+	r.Static("/tmp", "./assets/tmp")
 }

--- a/server/container/Dockerfile
+++ b/server/container/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libde265-dev \
   libx265-dev \
   libvips-dev \
+  ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 #Building latest libheif (v1.18.2)
@@ -44,6 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libde265-0 \
   libx265-199 \
   libheif1 \
+  ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 # Copy built libheif from builder
@@ -55,10 +57,10 @@ RUN ldconfig
 COPY --from=builder /app/server /server
 COPY ./config.yaml /config.yaml
 COPY ./secret.yml /secret.yml
-COPY ./assets/public /assets/public
-COPY ./assets/tmp /assets/tmp
-COPY ./assets/default /assets/default
-COPY ./assets/pfp /assets/pfp
+COPY ./assets /assets
+# COPY ./assets/tmp /assets/tmp
+# COPY ./assets/default /assets/default
+# COPY ./assets/pfp /assets/pfp
 
 EXPOSE 8080 8081 8082 8083
 

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -6,13 +6,19 @@
 # So later add a retry logic for few attempts with 5 sec delay assuming it will eventually connect
 # For now i wil add the restart condition in the docker compose file itself, the restart condition
 
+
+# TODO: changed ports mapping since conflict with local servers. To be rolled back.
+#       5673->5672
+#       15673->15672
+#       5435->5432
+
 services:
   rabbitmq:
     image: rabbitmq:3-management
     container_name: rabbitmq-1
     ports:
-      - "5672:5672"
-      - "15672:15672" # for the ui
+      - "5673:5672"
+      - "15673:15672" # for the ui
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 10s
@@ -26,7 +32,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: compass
     ports:
-      - "5432:5432"
+      - "5435:5432"
     # in health check change the user (i have set it to the value above)
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U this_is_mjk -d compass"]
@@ -49,7 +55,6 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
-    # No use, as we just run the binary
     environment:
       POSTGRES_HOST: postgres
       RABBITMQ_HOST: rabbitmq


### PR DESCRIPTION
assets/router.go: rerouted `"/assets/tmp"` to `"/tmp"` since static route `"/assets/tmp"` was being registered in conflict with "/assets/*" wildcard. Line not needed as the wildcard already routes "/assets/tmp" to the appropriate folder.