### PR TITLE
Fix: Visibility UI + Delete redirect

### DIFF
--- a/app/(auth)/profile/page.tsx
+++ b/app/(auth)/profile/page.tsx
@@ -31,6 +31,7 @@ export type Profile = {
   roomNo: string;
   homeTown: string;
   profilePic?: string;
+  visibility: boolean;
 };
 
 export type UserData = {

--- a/components/profile/EditableProfileCard.tsx
+++ b/components/profile/EditableProfileCard.tsx
@@ -37,6 +37,7 @@ export function EditableProfileCard({
   const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [formData, setFormData] = useState<Partial<Profile>>(profile);
+  const visibility = profile.visibility;
 
   // Sync form state if the profile prop changes (e.g., after a refetch)
   useEffect(() => {
@@ -122,7 +123,7 @@ export function EditableProfileCard({
                 Edit
               </Button>
               <AlertDeleteProfileInfo />
-              <AlertVisibilityProfileInfo initialVisibility={true} />
+              <AlertVisibilityProfileInfo currentVisibility={visibility} onVisibilityChange={() => onUpdate()}/>
             </>
           )}
         </div>

--- a/server/search/handler.userAction.go
+++ b/server/search/handler.userAction.go
@@ -42,8 +42,7 @@ func deleteProfileData(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Unable to delete profile"})
 		return
 	}
-	c.SetCookie("auth_token", "", -1, "/", "", true, true);
-	c.SetCookie("refresh_token", "", -1, "/", "", true, true);
+	middleware.ClearAuthCookie(c)
 	c.JSON(http.StatusOK, gin.H{"message": "User profile data deleted successfully"})
 }
 


### PR DESCRIPTION
Fixed visibility toggle button. Value is now fetched from the `profiles` table.
Fixed redirect to the login page when a user deletes their account.
NOTE: Pls remove the `console.log(data.profile.profile.visibility);` from ProfileAction.tsx (line 146).