### PR TITLE
added functionality of backup and restore with rclone using bash scripts

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -35,6 +35,9 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    vloumes:
+      - /srv/compass/postgres-data:/var/lib/postgresql/data
+      - /srv/compass/postgres-backups:/backups
   server:
     build:
       context: .
@@ -56,3 +59,7 @@ services:
       RABBITMQ_HOST: rabbitmq
       # force Go to use go.mod/go.sum for dependency management
       GO111MODULE: on
+    volumes:
+      - /srv/compass/data/pfp:/assets/pfp
+      - /srv/compass/data/public:/assets/public
+      - /srv/compass/data/tmp:/assets/tmp

--- a/server/scripts/backup_snapshot.sh
+++ b/server/scripts/backup_snapshot.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M")
+REMOTE="gdrive_encrypt:compass/snapshots/$TIMESTAMP"
+LOG="/srv/compass/logs/snapshot.log"
+
+echo "[$(date)] Starting snapshot $TIMESTAMP" >> "$LOG"
+
+rclone copy /srv/compass/data/public  "$REMOTE/public"
+rclone copy /srv/compass/data/tmp     "$REMOTE/tmp"
+rclone copy /srv/compass/postgres-backups "$REMOTE/postgres-backups"
+
+echo "[$(date)] Snapshot completed" >> "$LOG"

--- a/server/scripts/cleanup_old_backups.sh
+++ b/server/scripts/cleanup_old_backups.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+REMOTE="gdrive_encrypt:compass/snapshots"
+LOG="/srv/compass/logs/cleanup.log"
+
+echo "[$(date)] Cleaning old backups" >> "$LOG"
+
+rclone delete "$REMOTE" --min-age 14d --rmdirs
+
+echo "[$(date)] Cleanup complete" >> "$LOG"

--- a/server/scripts/pg_backup.sh
+++ b/server/scripts/pg_backup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M")
+BACKUP_DIR="/srv/compass/postgres-backups"
+LOG="/srv/compass/logs/pg_backup.log"
+
+echo "[$(date)] Starting Postgres backup" >> "$LOG"
+
+docker exec postgres \
+  pg_dumpall -U postgres \
+  | gzip > "$BACKUP_DIR/pg_dump_$TIMESTAMP.sql.gz"
+
+echo "[$(date)] Postgres backup complete" >> "$LOG"

--- a/server/scripts/production.sh
+++ b/server/scripts/production.sh
@@ -1,3 +1,21 @@
 #!/bin/bash
-# Script to deploy/prepare server for production
-# e.g., docker-compose down && docker-compose up -d --build
+
+# We can seperate cleaup_old_backups.sh script
+# so that we can run clean up jobs seperatly
+set -e
+
+echo "=== Backup started at $(date) ==="
+
+# 1. Database backup
+/srv/compass/scripts/pg_backup.sh
+
+# 2. Sync mirror
+/srv/compass/scripts/sync_mirror.sh
+
+# 3. Snapshot backup
+/srv/compass/scripts/backup_snapshot.sh
+
+# 4. Cleanup old snapshots
+/srv/compass/scripts/cleanup_old_backups.sh
+
+echo "=== Backup finished at $(date) ==="

--- a/server/scripts/restore_from_snapshot.sh
+++ b/server/scripts/restore_from_snapshot.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -e
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <YYYY-MM-DD_HH-MM>"
+  exit 1
+fi
+
+SNAPSHOT_DATE="$1"
+REMOTE="gdrive_encrypt:compass/snapshots/$SNAPSHOT_DATE"
+LOG="/srv/compass/logs/restore.log"
+
+APP_PUBLIC="/srv/compass/data/public"
+APP_TMP="/srv/compass/data/tmp"
+PG_BACKUPS="/srv/compass/postgres-backups"
+
+echo "===================================" | tee -a "$LOG"
+echo "RESTORE SNAPSHOT: $SNAPSHOT_DATE" | tee -a "$LOG"
+echo "START TIME: $(date)" | tee -a "$LOG"
+echo "===================================" | tee -a "$LOG"
+
+echo
+echo "WARNING: THIS WILL OVERWRITE LIVE DATA"
+echo "Snapshot: $REMOTE"
+echo
+read -p "Type RESTORE to continue: " CONFIRM
+
+if [ "$CONFIRM" != "RESTORE" ]; then
+  echo "Restore aborted"
+  exit 1
+fi
+
+# -------------------------
+# 1. Restore application data
+# -------------------------
+echo "[1/3] Restoring app data..." | tee -a "$LOG"
+
+rclone sync "$REMOTE/public" "$APP_PUBLIC"
+rclone sync "$REMOTE/tmp" "$APP_TMP"
+
+echo "App data restored" | tee -a "$LOG"
+
+# -------------------------
+# 2. Restore Postgres backup files
+# -------------------------
+echo "[2/3] Restoring Postgres backup files..." | tee -a "$LOG"
+
+rclone sync "$REMOTE/postgres-backups" "$PG_BACKUPS"
+
+echo "Postgres backup files restored" | tee -a "$LOG"
+
+# -------------------------
+# 3. Restore database
+# -------------------------
+echo "[3/3] Restoring Postgres database..." | tee -a "$LOG"
+
+LATEST_DUMP=$(ls -t "$PG_BACKUPS"/pg_dump_*.sql.gz | head -n 1)
+
+if [ -z "$LATEST_DUMP" ]; then
+  echo "No pg_dump file found!" | tee -a "$LOG"
+  exit 1
+fi
+
+echo "Using dump: $LATEST_DUMP" | tee -a "$LOG"
+
+read -p "This will DROP & REPLACE the database. Type YES to continue: " DB_CONFIRM
+if [ "$DB_CONFIRM" != "YES" ]; then
+  echo "Database restore aborted"
+  exit 1
+fi
+
+gunzip -c "$LATEST_DUMP" | docker exec -i postgres psql -U postgres
+
+echo "Database restored" | tee -a "$LOG"
+
+echo "===================================" | tee -a "$LOG"
+echo "RESTORE COMPLETED: $(date)" | tee -a "$LOG"
+echo "===================================" | tee -a "$LOG"

--- a/server/scripts/sync_mirror.sh
+++ b/server/scripts/sync_mirror.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+REMOTE="gdrive_encrypt:compass/mirror"
+LOG="/srv1/compass/logs/sync.log"
+
+echo "[$(date)] Starting mirror sync" >> "$LOG"
+
+rclone sync /srv/compass/data/public  "$REMOTE/public"  --delete-during
+rclone sync /srv/compass/data/tmp     "$REMOTE/tmp"     --delete-during
+rclone sync /srv/compass/postgres-backups "$REMOTE/postgres-backups" --delete-during
+
+echo "[$(date)] Mirror sync done" >> "$LOG"


### PR DESCRIPTION
With this PR the scripts needed for functionality of active backup in a drive with rclone are added to the project in the server/script folder the main file to run as a cron job is in production.sh
The file structure that will present on the server and and the drive backup will be as follows
Server:
/srv/compass/
├── postgres-data/        ← live PG data (DO NOT BACKUP DIRECTLY)
├── postgres-backups/     ← pg_dump files (SAFE to backup)
└── data/
    ├── tmp/
    ├── public/
    └── pfp/
Drive:
gdrive_encrypt:compass/
├── mirror/               ← latest synced state
│   ├── public/
│   ├── tmp/
|   └── pfp/
│   └── postgres-backups/
└── snapshots/            ← versioned backups
    ├── 2026-01-25_02-00/
    ├── 2026-01-26_02-00/
    └── ...
all these scripts will go into server in a folder at the path /srv/compass/scripts
also volumes needed to mount for this setup associated with their respective contianers are as follows

In postgres service container:
1. - /srv/compass/postgres-data:/var/lib/postgresql/data
2. - /srv/compass/postgres-backups:/backups
In server service container:
1. - /srv/compass/data/pfp:/assets/pfp
2. - /srv/compass/data/public:/assets/public
3. - /srv/compass/data/tmp:/assets/tmp

we need to run a cron job that runs the corn job of production.sh script at a particular time 
the software needed to be installed on the server are as follows:
1. rclone
2. cronie