### PR TITLE
fix: do not request to backend if decryption fails on frontend

### DIFF
--- a/search/src/components/ui/Options.tsx
+++ b/search/src/components/ui/Options.tsx
@@ -245,9 +245,11 @@ function Options(props: OptionsProps) {
       {isPuppyLove && (
         <div>
           <CardTitle>Puppy Love Mode active.</CardTitle>
-          <CardDescription className="flex-col sm:flex-row">
-            You can search other users here.
-          </CardDescription>
+          {PLpermit && (
+            <CardDescription className="flex-col sm:flex-row">
+              You can search other users here.
+            </CardDescription>
+          )}
         </div>
       )}
       {/* PuppyLove badge */}
@@ -422,9 +424,6 @@ function Options(props: OptionsProps) {
         ) : (
           <Card className="border-rose-200/40 bg-linear-to-br from-rose-50/80 via-pink-50/60 to-fuchsia-50/40 dark:border-rose-800/30 dark:from-rose-950/20 dark:via-pink-950/15 dark:to-fuchsia-950/10">
             <CardHeader>
-              <CardTitle className="text-rose-700 dark:text-rose-300">
-                Puppy Love Mode active.
-              </CardTitle>
               <CardDescription className="text-rose-500/80 dark:text-rose-400/60">
                 Do you want to get matched? If clicked yes, your profile will be
                 considered in the matching algorithm.

--- a/search/src/lib/workers/puppy_love_worker.ts
+++ b/search/src/lib/workers/puppy_love_worker.ts
@@ -210,6 +210,13 @@ self.addEventListener('message', async (e: MessageEvent) => {
 
       const claims = await Promise.all(
         decrypted.map(async (heart: any) => {
+          // FIX: Here if we had the decryption, result "Fail", still we were requesting the backend, checking if a sha value "Fail" exists, hence making the server overwhelmed when deadline.
+          if(heart.sha === "Fail") {
+            // console.log("Not sending the claim request as already decryption failed");
+            return {...heart, claim: {
+            "error": "Invalid Heart Claim Request.",
+            "claim_status": "false"}
+          };}
           const claimRes = await fetch(`${PUPPYLOVE_POINT}/api/puppylove/users/claimheart`, {
             method: 'POST',
             credentials: 'include',

--- a/search/src/lib/workers/utils.ts
+++ b/search/src/lib/workers/utils.ts
@@ -49,8 +49,7 @@ export async function setData(data: string, privateKey: string | null, idSelf: s
 
     }
 
-    console.log("Decrypted Receiver IDs:", decryptedReceiverIds);
-
+    // console.log("Decrypted Receiver IDs:", decryptedReceiverIds);
     return decryptedReceiverIds;
 }
 


### PR DESCRIPTION
When you observer the server logs you will find:
```2026/02/12 05:16:22 /app/puppylove/handler.user.go:386 record not found
server-1  | [0.362ms] [rows:0] SELECT * FROM "send_hearts" WHERE (sha = 'Fail' AND enc = 'NT8Pf4iwJQCoKNl9ecxOTGMDCNiH+EmY8UhORJ9NU/WOEyJ8bdn6iym/sHqemcy6W4bBOc7YCp41CNBAfiYl6qBYYfUWX3nF41kZSRCX2M+WtKKk2pcabIcw6scKLBdmcn2Nuz+/uFycxAtpXWb+OYII5J7wq93EzTlmOCjN6XMuqXd28a/gly4DipzGYba17okbOI7waZPkcXs4Ct63oLYcpmIAH8JpmFiNVg3+RbPm3RjDoPmDtvrmu+BSBt1cp+mQeT+UhgS2GOHDXGJRHDOC+A5lDWoJMxziQweEhGtSIqSicTxnaMB6Atixex4kU7c0/iTV42py4SRzOixEEw==') AND "send_hearts"."deleted_at" IS NULL ORDER BY "send_hearts"."id" LIMIT 1,
```

Here the issue is when ever a user fetches the send heart table, all encryptions will be decrypted, even it fails the claim request is sent, but the db returns an error that the sha = 'Fail' do not exist.

This slows down the process of the hearts claims and over all application, I just simply now check if the sha is 'Fail' or not, if so for safety I still add a dummy response to the results array, which the server would have returned

Other then that, I have done a small fix in the options.tsx to remove extra statements of the UI.