### PR TITLE
Allow owners to view pending review images

### DIFF
--- a/app/(auth)/profile/page.tsx
+++ b/app/(auth)/profile/page.tsx
@@ -83,7 +83,7 @@ export default function ProfilePage() {
       );
       if (res.ok) {
         const data = await res.json();
-
+        
         const normalized = {
           ...data,
           profile: {

--- a/app/components/user/Contribution_ReviewCard.tsx
+++ b/app/components/user/Contribution_ReviewCard.tsx
@@ -12,7 +12,9 @@ export type ReviewProps = {
   rating: number;
   review_body?: string;
   time: string;
-  imgs?: { ImageID: string }[];
+  imgs?: { ImageID: string ;
+           Status: string;
+          }[];
   // backend may return Location or location
   Location?: any;
   location?: any;
@@ -82,7 +84,19 @@ export default function ReviewCard(props: ReviewProps) {
   const locName = locFinal?.name || locFinal?.Name || null;
   const cover = locFinal?.coverpic || locFinal?.CoverPic || null;
 
-  const imageUrl = (imgId: string) => `${process.env.NEXT_PUBLIC_ASSET_URL}/assets/${imgId}.webp`;
+  // const imageUrl = (imgId: string) => `${process.env.NEXT_PUBLIC_ASSET_URL}/assets/${imgId}.webp`;
+  //
+  const reviewImageUrl = (img: any) => {
+      if (img.Status === "pending") {
+          return `${process.env.NEXT_PUBLIC_ASSET_URL}/protected-assets/${img.ImageID}`;
+      }
+
+      return `${process.env.NEXT_PUBLIC_ASSET_URL}/assets/${img.ImageID}.webp`;
+  };
+
+  const coverImageUrl = (id: string) =>
+      `${process.env.NEXT_PUBLIC_ASSET_URL}/assets/${id}.webp`;
+  //
 
   return (
     <Card className="mx-3 my-3 p-0 bg-white dark:bg-black text-black dark:text-white">
@@ -90,7 +104,7 @@ export default function ReviewCard(props: ReviewProps) {
         {/* Left: optional cover */}
         <div className="w-24 h-24 flex-shrink-0 rounded overflow-hidden bg-muted flex items-center justify-center">
           {cover ? (
-            <img src={imageUrl(cover)} alt={locName || "location"} className="w-full h-full object-cover" />
+            <img src={coverImageUrl(cover)} alt={locName || "location"} className="w-full h-full object-cover" />
           ) : (
             <ImageIcon className="h-8 w-8 text-muted-foreground" />
           )}
@@ -122,8 +136,8 @@ export default function ReviewCard(props: ReviewProps) {
             {imgs.length > 0 && (
               <div className="grid grid-cols-2 gap-2 mt-2">
                 {imgs.map((img : { ImageID: string }) => (
-                  <div className="relative w-full h-32 rounded-md overflow-hidden" key={img.ImageID}>
-                    <img src={imageUrl(img.ImageID)} alt="attachment" className="w-full h-full object-cover" />
+                    <div className="relative w-32 h-32 rounded-md overflow-hidden justify-self-start" key={img.ImageID}>
+                    <img src={reviewImageUrl(img)} alt="attachment" className="w-full h-full object-cover" />
                   </div>
                 ))}
               </div>

--- a/server/assets/handler.go
+++ b/server/assets/handler.go
@@ -203,3 +203,82 @@ func removeImage(c *gin.Context) {
 	})
 
 }
+
+func protectedAssetProvider(c *gin.Context) {
+	var image model.Image
+	imageIDParam := c.Param("imageId")
+	imageID, err := uuid.Parse(imageIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest,gin.H{"error":"Invalid image ID"})
+		return
+	}
+
+	if err := connections.DB.
+		Model(&model.Image{}).
+		Where("image_id = ?", imageID).
+		First(&image).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Image not found"})
+			return
+		} else {
+			logrus.Errorf("Failed to fetch image: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch image"})
+		}
+		logrus.Infof("Image from DB: %+v", image)
+		return
+	}
+
+	userID := c.MustGet("userID").(uuid.UUID)
+	logrus.Infof("Requested image: %s", imageID)
+	role := c.GetInt("userRole")
+
+	allowed := false
+
+	if image.Status == model.Approved {
+		allowed = true
+	}
+
+	if image.OwnerID == userID {
+		allowed = true
+	}
+
+	if role >= int(model.AdminRole) {
+		allowed = true
+	}
+
+	if !allowed {
+		c.JSON(http.StatusForbidden,
+			gin.H{"error":"Forbidden"})
+		return
+	}
+
+	cwd, _ := os.Getwd()
+
+	var path string
+
+	switch image.Status {
+
+	case model.Pending:
+		path = filepath.Join(
+			cwd,
+			"assets",
+			"tmp",
+			image.ImageID.String()+".webp",
+		)
+
+	case model.Approved:
+		path = filepath.Join(
+			cwd,
+			"assets",
+			"public",
+			image.ImageID.String()+".webp",
+		)
+
+	default:
+		c.JSON(http.StatusInternalServerError,
+			gin.H{"error":"Unknown image status"})
+		return
+	}
+	logrus.Infof("Serving file: %s", path)
+	c.File(path)
+}

--- a/server/assets/router.go
+++ b/server/assets/router.go
@@ -40,6 +40,7 @@ func Router(r *gin.Engine) {
 	{
 		protected.Static("/pfp", "./assets/pfp")
 		protected.POST("/assets", uploadAsset)
+		protected.GET("/protected-assets/:imageId", protectedAssetProvider)
 
 	}
 


### PR DESCRIPTION
## Problem

Review images with `pending` status were stored in `assets/tmp` and could not be displayed on the profile page because the frontend always requested images from the public `/assets` endpoint.

## Solution

- Added a protected asset endpoint for review images.
- Implemented backend authorization so an image is served only if:
  - the image is approved, or
  - the requester is the image owner, or
  - the requester is an admin.
- Updated the frontend to request pending images through the protected endpoint while continuing to use the public endpoint for approved images.