### PR TITLE
Fixed the Error of NoticeBoard not showing Images.

### DIFF
--- a/app/(maps)/noticeboard/[id]/page.tsx
+++ b/app/(maps)/noticeboard/[id]/page.tsx
@@ -6,22 +6,14 @@ import { useParams } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-interface Notice {
-  id: string;
-  title: string;
-  description: string;
-  body: string;
-  type: string;
-  location: string;
-  time: string;
-}
-
+import { Notice } from "@/lib/types";
 export default function UserNoticeDetailPage() {
   const params = useParams();
   const id = params.id as string;
 
   const [notice, setNotice] = useState<Notice | null>(null);
   const [loading, setLoading] = useState(true);
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
 
   useEffect(() => {
     if (!id) return;
@@ -33,18 +25,11 @@ export default function UserNoticeDetailPage() {
           `${process.env.NEXT_PUBLIC_MAPS_URL}/api/maps/notice/${id}`
         );
         if (!res.ok) throw new Error("Notice not found");
-        
+
         const data = await res.json();
-        
-        setNotice({
-          id: data.id,
-          title: data.title,
-          description: data.description,
-          body: data.body,
-          type: data.entity,
-          location: data.location,
-          time: data.eventTime,
-        });
+
+        setNotice(data);
+        console.log("Fetched notice:", data);
       } catch (err) {
         console.error("Failed to fetch notice:", err);
       } finally {
@@ -55,6 +40,20 @@ export default function UserNoticeDetailPage() {
     fetchNotice();
   }, [id]);
 
+  // Lock page scroll while lightbox is open, and allow Esc to close
+  useEffect(() => {
+    if (!lightboxUrl) return;
+    document.body.style.overflow = "hidden";
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setLightboxUrl(null);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.body.style.overflow = "";
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [lightboxUrl]);
+
   if (loading) return <div className="p-10 text-center">Loading notice...</div>;
   if (!notice) return <div className="p-10 text-center">Sorry, we couldn`&apos;`t find that notice.</div>;
 
@@ -64,19 +63,64 @@ export default function UserNoticeDetailPage() {
         <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-2">
           {notice.title}
         </h1>
+        {notice.coverPic ? (
+          <img
+            src={`${process.env.NEXT_PUBLIC_ASSET_URL}/assets/${notice.coverPic.ImageID}.webp`}
+            alt="Cover"
+            className="w-full h-64 object-cover rounded-lg mb-6"
+            onClick={() =>
+              setLightboxUrl(`${process.env.NEXT_PUBLIC_ASSET_URL}/assets/${notice.coverPic.ImageID}.webp`)
+            }
+          />
+        ) : (
+          <p className="text-gray-500">No cover image available</p>
+        )}
+        {notice.bioPics && notice.bioPics.length > 0 && (
+          <div className="flex space-x-4 mb-6">
+            {notice.bioPics.map((bioPic, index) => (
+              <img src={`${process.env.NEXT_PUBLIC_ASSET_URL}/assets/${bioPic.ImageID}.webp`} alt={`Bio Pic ${index + 1}`} key={index} className="w-24 h-24 object-cover rounded-lg"
+                onClick={() =>
+                  setLightboxUrl(`${process.env.NEXT_PUBLIC_ASSET_URL}/assets/${bioPic.ImageID}.webp`)
+                } />
+            ))}
+          </div>
+        )}
+
         <div className="text-sm text-gray-500 mb-6">
           <span><strong>Location:</strong> {notice.location}</span>
           <span className="ml-4">
-            <strong>Time:</strong> {new Date(notice.time).toLocaleString()}
+            <strong>Time:</strong> {new Date(notice.createdAt).toLocaleString()}
           </span>
         </div>
-        
+
         <article className="markdown-content">
           <ReactMarkdown remarkPlugins={[remarkGfm]}>
             {notice.body}
           </ReactMarkdown>
         </article>
       </div>
+
+      {/* Lightbox overlay */}
+      {lightboxUrl && (
+        <div
+          onClick={() => setLightboxUrl(null)}
+          className="fixed inset-0 bg-gray-900 bg-opacity-50 flex items-center justify-center z-50 p-4"
+        >
+          <button
+            onClick={() => setLightboxUrl(null)}
+            className="absolute top-4 right-4 text-white text-3xl leading-none"
+            aria-label="Close"
+          >
+            &times;
+          </button>
+          <img
+            src={lightboxUrl}
+            alt="Full size"
+            onClick={(e) => e.stopPropagation()}
+            className="max-w-full max-h-full object-contain rounded-lg"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/app/(maps)/noticeboard/page.tsx
+++ b/app/(maps)/noticeboard/page.tsx
@@ -10,16 +10,7 @@ import { toast } from "sonner";
 import { NoticeCard } from "@/components/noticeboard/NoticeComponent";
 import { AuthGuard } from "@/components/AuthGuard";
 
-interface Notice {
-  id: string;
-  title: string;
-  description: string;
-  body: string;
-  entity: string;
-  location: string;
-  eventTime: string;
-}
-
+import { Notice } from "@/lib/types";
 export default function NoticeBoardPage() {
   const [searchTerm, setSearchTerm] = useState("");
   const [shareNotice, setShareNotice] = useState<Notice | null>(null);

--- a/app/admin/publishNotice/PublishForm.tsx
+++ b/app/admin/publishNotice/PublishForm.tsx
@@ -199,10 +199,12 @@ export default function NoticeboardForm() {
   };
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-
+    const readyImages = images.filter((img) => img.id !== null);
     try {
       const payload = {
         ...formData,
+        coverPic: readyImages[0]?.id ?? null,
+        bioPics: readyImages.slice(1).map((img) => img.id),
         eventEndTime: formData.eventEndTime
           ? new Date(formData.eventEndTime).toISOString()
           : null,
@@ -238,22 +240,22 @@ export default function NoticeboardForm() {
   };
 
   function isoToDatetimeLocal(iso: string) {
-  const date = new Date(iso);
+    const date = new Date(iso);
 
-  const pad = (n: number) => String(n).padStart(2, "0");
+    const pad = (n: number) => String(n).padStart(2, "0");
 
-  return (
-    date.getFullYear() +
-    "-" +
-    pad(date.getMonth() + 1) +
-    "-" +
-    pad(date.getDate()) +
-    "T" +
-    pad(date.getHours()) +
-    ":" +
-    pad(date.getMinutes())
-  );
-}
+    return (
+      date.getFullYear() +
+      "-" +
+      pad(date.getMonth() + 1) +
+      "-" +
+      pad(date.getDate()) +
+      "T" +
+      pad(date.getHours()) +
+      ":" +
+      pad(date.getMinutes())
+    );
+  }
 
 
   // Clean up all object URLs when the component unmounts

--- a/app/components/lib/types.ts
+++ b/app/components/lib/types.ts
@@ -17,25 +17,26 @@ interface Actions {
   function?: () => void;
 }
 
-export interface Notice {
-  id: string;
-  title: string;
-  description: string;
-  publisher: string;
-  eventTime: string;
-  eventEndTime: string;
-  location: string;
-  entity: string;
-}
+//According to me (Rohit Kumar , Y25) , these interfaces are not in use .
+// export interface Notice {
+//   id: string;
+//   title: string;
+//   description: string;
+//   publisher: string;
+//   eventTime: string;
+//   eventEndTime: string;
+//   location: string;
+//   entity: string;
+// }
 
-export interface Img {
-    CreatedAt: Date;
-    UpdatedAt: Date;
-    DeletedAt: Date;
-    ImageID: String;
-    OwnerID: String;
-    ParentAssetID: String;
-    ParentAssetType: String;
-    Status: String;
-    Submitted: boolean;
-}
+// export interface Img {
+//     CreatedAt: Date;
+//     UpdatedAt: Date;
+//     DeletedAt: Date;
+//     ImageID: string;
+//     OwnerID: string;
+//     ParentAssetID: string;
+//     ParentAssetType: string;
+//     Status: string;
+//     Submitted: boolean;
+// }

--- a/components/noticeboard/NoticeComponent.tsx
+++ b/components/noticeboard/NoticeComponent.tsx
@@ -1,19 +1,12 @@
 import { useRouter } from "next/navigation";
 
-import {  Share2, Copy, Edit, Trash } from "lucide-react";
+import { Share2, Copy, Edit, Trash } from "lucide-react";
 
 
 import { useGContext } from "@/components/ContextProvider";
 import { toast } from "sonner";
-interface Notice {
-  id: string;
-  title: string;
-  description: string;
-  body: string;
-  entity: string;
-  location: string;
-  eventTime: string;
-}
+import { Notice } from "@/lib/types";
+
 
 const NoticeCard = ({
   notice,
@@ -72,6 +65,14 @@ const NoticeCard = ({
       <h2 className="text-xl font-bold text-gray-800 group-hover:text-blue-600 transition-colors">
         {notice.title}
       </h2>
+      {notice.coverPic ? (
+        <img
+          src={`${process.env.NEXT_PUBLIC_ASSET_URL}/assets/${notice.coverPic.ImageID}.webp`}
+          alt="Cover"
+          className="w-full h-48 object-cover rounded-lg mt-3"
+          
+        />
+      ) : <p className="text-gray-500">No cover image available</p>}
       <p className="text-gray-600 mt-2">{notice.description}</p>
       <div className="text-sm text-gray-500 mt-4">
         <span>

--- a/components/ui/NoticeCard.tsx
+++ b/components/ui/NoticeCard.tsx
@@ -1,132 +1,145 @@
-'use client';
+// //NoticeCard.tsx , I Think this file is not in use
 
-import React, { useState, useEffect } from 'react';
-import {
-  Share2,
-  Calendar,
-  MapPin,
-  Building,
-} from 'lucide-react';
-import { Notice } from '@/lib/types';
 
-function NoticeCard({
-  notice,
-  isExpanded,
-  onToggleExpand,
-  
-  onShare,
-}: {
-  notice: Notice;
-  isExpanded: boolean;
-  onToggleExpand: () => void;
-  onShare: (notice: Notice) => void;
-   onCopy: (notice: Notice) => void;
-}) {
-  const formattedDate = new Date(notice.eventTime).toLocaleString('en-US', {
-    weekday: 'short',
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
 
-  const truncatedDescription =
-    notice.description.length > 120
-      ? notice.description.slice(0, 120) + '...'
-      : notice.description;
 
-  // defining carousel state for biopics
-  const [currentIndex, setCurrentIndex] = useState(0);
 
-  useEffect(() => {
-    if (!notice.biopics || notice.biopics.length === 0) return;
+// 'use client';
 
-    const interval = setInterval(() => {
-      setCurrentIndex((prev) => (prev + 1) % notice.biopics.length);
-    }, 2000); // this is auto scroll every 2s
+// import React, { useState, useEffect } from 'react';
+// import Image from 'next/image';
+// import {
+//   Share2,
+//   Calendar,
+//   MapPin,
+//   Building,
+// } from 'lucide-react';
+// import { Notice } from '@/lib/types';
 
-    return () => clearInterval(interval);
-  }, [notice.biopics]);
+// function NoticeCard({
+//   notice,
+//   isExpanded,
+//   onToggleExpand,
 
-  return (
-    <div className="bg-white border border-gray-200 rounded-2xl shadow-md transition hover:shadow-lg overflow-hidden">
-      <div className="p-6 space-y-3">
-        <div className="flex lg:flex-row flex-col justify-between items-start">
-          <h3 className="text-xl font-semibold text-gray-900">{notice.title}</h3>
-          <span className="flex items-center gap-1 text-xs font-medium bg-blue-100 text-blue-800 px-2 py-1 rounded-full">
-            <Building className="w-3 h-3" />
-            {notice.entity}
-          </span>
-        </div>
+//   onShare,
+// }: {
+//   notice: Notice;
+//   isExpanded: boolean;
+//   onToggleExpand: () => void;
+//   onShare: (notice: Notice) => void;
+//   onCopy: (notice: Notice) => void;
+// }) {
+//   const formattedDate = new Date(notice.eventTime).toLocaleString('en-US', {
+//     weekday: 'short',
+//     year: 'numeric',
+//     month: 'short',
+//     day: 'numeric',
+//     hour: '2-digit',
+//     minute: '2-digit',
+//   });
 
-        {/* Cover Picture */}
-        {notice.coverpic && (
-          <img
-           src={`/assets/${notice.coverpic.id}.webp`}
-            alt="Cover"
-            className="w-full h-48 object-cover rounded-lg"
-          />
-        )}
+//   const truncatedDescription =
+//     notice.description.length > 120
+//       ? notice.description.slice(0, 120) + '...'
+//       : notice.description;
 
-        <p className="text-gray-700 text-sm leading-relaxed">
-          {isExpanded ? notice.description : truncatedDescription}
-        </p>
+//   // defining carousel state for biopics
+//   const [currentIndex, setCurrentIndex] = useState(0);
 
-        {/* Bio Pics Carousel */}
-        {notice.biopics && notice.biopics.length > 0 && (
-          <div className="relative w-full h-40 overflow-hidden rounded-lg">
-            <div
-              className="flex transition-transform duration-500 ease-in-out"
-              style={{
-                transform: `translateX(-${currentIndex * 100}%)`,
-                width: `${notice.biopics.length * 100}%`,
-              }}
-            >
-              {notice.biopics.map((pic) => (
-                <img
-                  key={pic.id}
-    src={`/assets/${pic.id}.webp`}
-                  alt="Bio"
-                  className="w-full h-40 object-cover shrink-0"
-                />
-              ))}
-            </div>
-          </div>
-        )}
+//   useEffect(() => {
+//     if (!notice.biopics || notice.biopics.length === 0) return;
 
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-y-2 text-sm text-gray-600">
-          <div className="flex items-center gap-2">
-            <Calendar className="w-4 h-4 text-gray-500" />
-            {formattedDate}
-          </div>
-          <div className="flex items-center gap-2 col-span-2 sm:col-span-1">
-            <MapPin className="w-4 h-4 text-gray-500" />
-            {notice.location}
-          </div>
-        </div>
-      </div>
+//     const interval = setInterval(() => {
+//       setCurrentIndex((prev) => (prev + 1) % notice.biopics.length);
+//     }, 2000); // this is auto scroll every 2s
 
-      <div className="border-t border-gray-100 px-6 py-3 flex justify-between items-center bg-gray-50">
-        <button
-          onClick={onToggleExpand}
-          className="text-sm text-blue-600 hover:text-blue-800 font-medium transition hover:underline"
-        >
-          {isExpanded ? 'Show less' : 'Details'}
-        </button>
-        <div className="flex gap-2">
-          <button
-            onClick={() => onShare(notice)}
-            className="w-9 h-9 rounded-full bg-white border border-gray-300 hover:bg-gray-100 flex items-center justify-center"
-            title="Share"
-            aria-label="Share notice"
-          >
-            <Share2 className="w-4 h-4 text-gray-600" />
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
+//     return () => clearInterval(interval);
+//   }, [notice.biopics]);
 
-export default NoticeCard;
+//   return (
+//     <div className="bg-white border border-gray-200 rounded-2xl shadow-md transition hover:shadow-lg overflow-hidden">
+//       <div className="p-6 space-y-3">
+//         <div className="flex lg:flex-row flex-col justify-between items-start">
+//           <h3 className="text-xl font-semibold text-gray-900">{notice.title}</h3>
+//           <span className="flex items-center gap-1 text-xs font-medium bg-blue-100 text-blue-800 px-2 py-1 rounded-full">
+//             <Building className="w-3 h-3" />
+//             {notice.entity}
+//           </span>
+//         </div>
+
+//         {/* Cover Picture */}
+//         {notice.coverpic && (
+//           <Image
+//             src={`${process.env.NEXT_PUBLIC_ASSET_URL}/assets/${notice.coverpic.id}.webp`}
+//             alt="Cover"
+//             className="w-full h-48 object-cover rounded-lg"
+//             width={500}
+//             height={300}
+//           />
+//         )}
+
+//         <p className="text-gray-700 text-sm leading-relaxed">
+//           {isExpanded ? notice.description : truncatedDescription}
+//         </p>
+
+//         {/* Bio Pics Carousel */}
+//         {notice.biopics && notice.biopics.length > 0 && (
+//           <div className="relative w-full h-40 overflow-hidden rounded-lg">
+//             <div
+//               className="flex transition-transform duration-500 ease-in-out"
+//               style={{
+//                 transform: `translateX(-${currentIndex * 100}%)`,
+//                 width: `${notice.biopics.length * 100}%`,
+//               }}
+//             >
+//               {notice.biopics
+//                 .filter((pic) => pic.id)
+//                 .map((pic) => (
+//                   <Image
+//                     key={pic.id}
+//                     src={`${process.env.NEXT_PUBLIC_ASSET_URL}/assets/${pic.id}.webp`}
+//                     alt="Bio"
+//                     className="w-full h-40 object-cover shrink-0"
+//                     width={500}
+//                     height={300}
+//                   />
+//                 ))}
+//             </div>
+//           </div>
+//         )}
+
+//         <div className="grid grid-cols-2 sm:grid-cols-3 gap-y-2 text-sm text-gray-600">
+//           <div className="flex items-center gap-2">
+//             <Calendar className="w-4 h-4 text-gray-500" />
+//             {formattedDate}
+//           </div>
+//           <div className="flex items-center gap-2 col-span-2 sm:col-span-1">
+//             <MapPin className="w-4 h-4 text-gray-500" />
+//             {notice.location}
+//           </div>
+//         </div>
+//       </div>
+
+//       <div className="border-t border-gray-100 px-6 py-3 flex justify-between items-center bg-gray-50">
+//         <button
+//           onClick={onToggleExpand}
+//           className="text-sm text-blue-600 hover:text-blue-800 font-medium transition hover:underline"
+//         >
+//           {isExpanded ? 'Show less' : 'Details'}
+//         </button>
+//         <div className="flex gap-2">
+//           <button
+//             onClick={() => onShare(notice)}
+//             className="w-9 h-9 rounded-full bg-white border border-gray-300 hover:bg-gray-100 flex items-center justify-center"
+//             title="Share"
+//             aria-label="Share notice"
+//           >
+//             <Share2 className="w-4 h-4 text-gray-600" />
+//           </button>
+//         </div>
+//       </div>
+//     </div>
+//   );
+// }
+
+// export default NoticeCard;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,7 @@
 export interface Image {
-  id: string;
+  ImageID: string;
   url: string;
-  ownerId: string;
+  OwnerID: string;
   ownerType: string;
   createdAt: string;
   updatedAt: string;
@@ -12,13 +12,14 @@ export interface Notice {
   id: string;
   title: string;
   description: string;
+  body: string;
   // publisher: string;    // Person or org name
   entity: string;          //to represent department / Club / Cell
   eventTime: string;       // ISO date string
   eventEndTime: string;    // ISO date string
   location: string;
-  coverpic?: Image;        // single image
-  biopics: Image[];        // multiple images
+  coverPic?: Image;        // single image
+  bioPics: Image[];        // multiple images
   createdAt: string;
   updatedAt: string;
   deletedAt?: string;

--- a/server/maps/handler.adminActions.go
+++ b/server/maps/handler.adminActions.go
@@ -216,6 +216,25 @@ func addNotice(c *gin.Context) {
 				return err
 			}
 		}
+
+		if input.BioPics != nil && len(*input.BioPics) > 0 {
+			if err := tx.Model(&model.Image{}).
+				Where("image_id IN ?", *input.BioPics).
+				Updates(map[string]interface{}{
+					"ParentAssetID":   notice.NoticeId,
+					"ParentAssetType": "notices",
+					"Submitted":       true,
+					"Status":          "approved",
+				}).Error; err != nil {
+				return err
+			}
+			for _, imgID := range *input.BioPics {
+				if err := assets.MoveImageFromTmpToPublic(imgID); err != nil {
+					return err
+				}
+			}
+		}
+		
 		return nil
 	}); err != nil {
 		logrus.Error("Failed to create notice:", err)
@@ -483,7 +502,7 @@ func editLocation(c *gin.Context) {
 	loc.Time = input.Time
 	loc.Contact = input.Contact
 	loc.LocationType = input.LocationType
-	loc.Layer = int(input.Layer) 
+	loc.Layer = int(input.Layer)
 
 	if err := connections.DB.Save(&loc).Error; err != nil {
 		logrus.WithError(err).Error("Failed to update location")

--- a/server/maps/handler.userStaticData.go
+++ b/server/maps/handler.userStaticData.go
@@ -32,6 +32,8 @@ func noticeProvider(c *gin.Context) {
 	query := connections.DB.
 		Model(&model.Notice{}).
 		Preload("User", connections.UserSelect).
+		Preload("CoverPic", connections.ImageSelect).
+		Preload("BioPics", connections.ImageSelect).
 		Order("created_at DESC")
 
 	var noticeList []model.Notice
@@ -58,7 +60,7 @@ func noticeProvider(c *gin.Context) {
 			return
 		}
 
-		// Count total notices 
+		// Count total notices
 		var count int64
 		if err := connections.DB.Model(&model.Notice{}).Count(&count).Error; err != nil {
 			logrus.Errorf("Failed to count notices: %v", err)
@@ -76,7 +78,7 @@ func noticeProvider(c *gin.Context) {
 		return
 	}
 
-	// No pagination 
+	// No pagination
 	if err := query.Find(&noticeList).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "Failed to fetch notices",
@@ -94,7 +96,7 @@ func noticeProvider(c *gin.Context) {
 // noticeDetailProvider fetches a single notice by its ID using GORM.
 func noticeDetailProvider(c *gin.Context) {
 
-	// Get and validate the ID from the URL
+	// Get and validate the ID from the URL\
 	noticeIDStr := c.Param("id")
 	noticeID, err := uuid.Parse(noticeIDStr)
 	if err != nil {
@@ -107,6 +109,8 @@ func noticeDetailProvider(c *gin.Context) {
 	result := connections.DB.
 		Model(&model.Notice{}).
 		Preload("User", connections.UserSelect). // Preload user data, just like in noticeProvider
+		Preload("CoverPic", connections.ImageSelect).
+		Preload("BioPics", connections.ImageSelect).
 		Where("notice_id = ?", noticeID).
 		First(&notice) // Use First() to get a single record
 

--- a/server/maps/request.model.go
+++ b/server/maps/request.model.go
@@ -37,6 +37,7 @@ type AddNoticeRequest struct {
 	Description  string     `json:"description" binding:"required"`
 	Body         string     `json:"body"`
 	CoverPic     *uuid.UUID `json:"coverPic"`
+	BioPics      *[]uuid.UUID `json:"bioPics"`
 	Entity       string     `json:"entity"`
 	EventTime    time.Time  `json:"eventTime"`
 	EventEndTime time.Time  `json:"eventEndTime"`

--- a/server/model/compass.go
+++ b/server/model/compass.go
@@ -54,7 +54,8 @@ type Notice struct { // change this to ritika's PR, can remove the contributedBy
 	Body          string         `json:"body,omitempty"` // added omitempty
 	ContributedBy uuid.UUID      `json:"contributedBy"`
 	User          *User          `gorm:"foreignKey:ContributedBy;references:UserID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;" json:"user,omitempty"`
-	CoverPic      *Image         `gorm:"polymorphic:ParentAsset;" json:"coverpic,omitempty"`
+	CoverPic      *Image         `gorm:"polymorphic:ParentAsset;" json:"coverPic"`
+	BioPics       []Image        `gorm:"polymorphic:ParentAsset;" json:"bioPics"` 
 }
 
 type Review struct {


### PR DESCRIPTION
## Summary by Sourcery

Enable full image support for noticeboard notices, including cover and bio images, and align frontend/backend types and APIs with the new image model.

New Features:
- Add cover and bio image rendering on notice list and detail pages using the public asset URL.
- Introduce a lightbox overlay for viewing notice images in full size with click and Esc-to-close behavior.

Bug Fixes:
- Ensure published notices send cover and bio image IDs to the backend so associated images become visible to users.
- Preload cover and bio images for notices in user-facing APIs so they are returned with notice data.
- Correct Notice and Image type definitions to match backend JSON fields, preventing mismatches that hid images.

Enhancements:
- Refactor noticeboard components to share the central Notice type instead of local interfaces.
- Update server-side notice model JSON tags to use consistent coverPic and bioPics naming.
- Mark unused legacy Notice and Img interfaces and an old NoticeCard implementation as commented-out code.