### PR TITLE
fixed some issues

### DIFF
--- a/app/admin/publishNotice/PublishForm.tsx
+++ b/app/admin/publishNotice/PublishForm.tsx
@@ -200,9 +200,22 @@ export default function NoticeboardForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    if (formData.eventTime && formData.eventEndTime) {
+      const start = new Date(formData.eventTime);
+      const end = new Date(formData.eventEndTime);
+      if (end < start) {
+        toast.error("Event end time cannot be before start time");
+        return;
+      }
+    }
+
     try {
       const payload = {
-        ...formData,
+        title: formData.title,
+        description: formData.description,
+        entity: formData.type,
+        location: formData.location,
+        body: formData.body,
         eventEndTime: formData.eventEndTime
           ? new Date(formData.eventEndTime).toISOString()
           : null,
@@ -239,6 +252,7 @@ export default function NoticeboardForm() {
 
   function isoToDatetimeLocal(iso: string) {
   const date = new Date(iso);
+  if (isNaN(date.getTime()) || date.getFullYear() < 1970) return "";
 
   const pad = (n: number) => String(n).padStart(2, "0");
 
@@ -296,9 +310,22 @@ export default function NoticeboardForm() {
     e.preventDefault();
     if (!noticeId) return;
 
+    if (formData.eventTime && formData.eventEndTime) {
+      const start = new Date(formData.eventTime);
+      const end = new Date(formData.eventEndTime);
+      if (end < start) {
+        toast.error("Event end time cannot be before start time");
+        return;
+      }
+    }
+
     try {
       const payload = {
-        ...formData,
+        title: formData.title,
+        description: formData.description,
+        entity: formData.type,
+        location: formData.location,
+        body: formData.body,
         eventEndTime: formData.eventEndTime
           ? new Date(formData.eventEndTime).toISOString()
           : null,

--- a/app/admin/publishNotice/PublishForm.tsx
+++ b/app/admin/publishNotice/PublishForm.tsx
@@ -342,13 +342,13 @@ export default function NoticeboardForm() {
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-6">
-          {["title", "description"].map((field) => (
+          {[{ name: "title", maxLength: 50 }, { name: "description", maxLength: undefined }].map(({ name: field, maxLength }) => (
             <div key={field}>
               <Label
                 htmlFor={field}
                 className="block text-sm font-medium capitalize"
               >
-                {field}
+                {field}{field === "title" && <span className="ml-2 text-xs text-muted-foreground font-normal">{formData.title.length}/50</span>}
               </Label>
               <Input
                 id={field}
@@ -358,6 +358,7 @@ export default function NoticeboardForm() {
                 // TODO: add correct interface NoticeFormData
                 value={(formData as any)[field]}
                 onChange={handleChange}
+                maxLength={maxLength}
                 className="mt-1 w-full px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-gray-900 placeholder:text-gray-400 dark:bg-gray-800 dark:border-gray-600 dark:placeholder-gray-500 dark:text-white"
                 required
               />

--- a/app/components/location/EditLocationModal.tsx
+++ b/app/components/location/EditLocationModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useHistoryBack } from "@/app/hooks/use-history-back";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -70,6 +71,9 @@ export function EditLocationModal({
   const [isOpen, setIsOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  // Close modal on phone back button instead of navigating away
+  useHistoryBack(isOpen, () => setIsOpen(false));
 
   const [formData, setFormData] = useState({
     name: "",

--- a/app/components/location/ReviewDrawer.tsx
+++ b/app/components/location/ReviewDrawer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useHistoryBack } from "@/app/hooks/use-history-back";
 import { Button } from "@/components/ui/button";
 import {
   Drawer,
@@ -42,6 +43,9 @@ export function ReviewDrawer({
   const [isOpen, setIsOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  // Close drawer on phone back button instead of navigating away
+  useHistoryBack(isOpen, () => setIsOpen(false));
 
   const handleSubmit = async () => {
     if (!rating) {

--- a/app/hooks/use-history-back.ts
+++ b/app/hooks/use-history-back.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Intercepts the browser/phone back button to close a drawer/dialog
+ * instead of navigating away. Essential for PWA UX on mobile.
+ *
+ * When `isOpen` becomes true, a dummy history entry is pushed.
+ * Pressing back pops that entry and calls `onClose` instead of navigating.
+ */
+export function useHistoryBack(isOpen: boolean, onClose: () => void) {
+  // Store onClose in a ref so the effect doesn't re-run when the
+  // parent passes an unstable (inline) callback reference.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  const didPushRef = useRef(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      // Push a dummy state so that "back" stays on the same page
+      window.history.pushState({ drawerOpen: true }, "");
+      didPushRef.current = true;
+
+      const handlePopState = () => {
+        // Back was pressed — close the drawer instead of navigating
+        didPushRef.current = false;
+        onCloseRef.current();
+      };
+
+      window.addEventListener("popstate", handlePopState);
+
+      return () => {
+        window.removeEventListener("popstate", handlePopState);
+        // If the drawer was closed programmatically (not via back button),
+        // clean up the dummy history entry we pushed
+        if (didPushRef.current) {
+          didPushRef.current = false;
+          window.history.back();
+        }
+      };
+    }
+  }, [isOpen]); // Only re-run when open state actually changes
+}

--- a/calendar/components/dialogs/add-event-dialog.tsx
+++ b/calendar/components/dialogs/add-event-dialog.tsx
@@ -108,7 +108,7 @@ export function AddEventDialog({ children, startDate, startTime }: IProps) {
                 <FormItem>
                   <FormLabel htmlFor="title">Title</FormLabel>
                   <FormControl>
-                    <Input id="title" placeholder="Event title" data-invalid={fieldState.invalid} {...field} />
+                    <Input id="title" placeholder="Event title" maxLength={50} data-invalid={fieldState.invalid} {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/calendar/components/dialogs/add-event-dialog.tsx
+++ b/calendar/components/dialogs/add-event-dialog.tsx
@@ -126,7 +126,10 @@ export function AddEventDialog({ children, startDate, startTime }: IProps) {
                       <SingleDayPicker
                         id="startDate"
                         value={field.value}
-                        onSelect={date => field.onChange(date as Date)}
+                        onSelect={date => {
+                          field.onChange(date as Date);
+                          form.trigger(["startTime", "endTime", "startDate", "endDate", "recurrenceEndDate"]);
+                        }}
                         placeholder="Select a date"
                         data-invalid={fieldState.invalid}
                       />
@@ -143,7 +146,10 @@ export function AddEventDialog({ children, startDate, startTime }: IProps) {
                   <FormItem className="flex-1">
                     <FormLabel>Start Time</FormLabel>
                     <FormControl>
-                      <TimeInput value={field.value as TimeValue} onChange={field.onChange} hourCycle={12} data-invalid={fieldState.invalid} />
+                      <TimeInput value={field.value as TimeValue} onChange={time => {
+                        field.onChange(time);
+                        form.trigger(["startTime", "endTime", "startDate", "endDate", "recurrenceEndDate"]);
+                      }} hourCycle={12} data-invalid={fieldState.invalid} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -161,7 +167,10 @@ export function AddEventDialog({ children, startDate, startTime }: IProps) {
                     <FormControl>
                       <SingleDayPicker
                         value={field.value}
-                        onSelect={date => field.onChange(date as Date)}
+                        onSelect={date => {
+                          field.onChange(date as Date);
+                          form.trigger(["startTime", "endTime", "startDate", "endDate", "recurrenceEndDate"]);
+                        }}
                         placeholder="Select a date"
                         data-invalid={fieldState.invalid}
                       />
@@ -178,7 +187,10 @@ export function AddEventDialog({ children, startDate, startTime }: IProps) {
                   <FormItem className="flex-1">
                     <FormLabel>End Time</FormLabel>
                     <FormControl>
-                      <TimeInput value={field.value as TimeValue} onChange={field.onChange} hourCycle={12} data-invalid={fieldState.invalid} />
+                      <TimeInput value={field.value as TimeValue} onChange={time => {
+                        field.onChange(time);
+                        form.trigger(["startTime", "endTime", "startDate", "endDate", "recurrenceEndDate"]);
+                      }} hourCycle={12} data-invalid={fieldState.invalid} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -256,7 +268,10 @@ export function AddEventDialog({ children, startDate, startTime }: IProps) {
                     <FormControl>
                       <SingleDayPicker
                         value={field.value ?? undefined}
-                        onSelect={date => field.onChange(date as Date)}
+                        onSelect={date => {
+                          field.onChange(date as Date);
+                          form.trigger(["startTime", "endTime", "startDate", "endDate", "recurrenceEndDate"]);
+                        }}
                         placeholder="No end date (forever)"
                         data-invalid={fieldState.invalid}
                       />

--- a/calendar/components/dialogs/edit-event-dialog.tsx
+++ b/calendar/components/dialogs/edit-event-dialog.tsx
@@ -288,7 +288,7 @@ export function EditEventDialog({ children, event }: IProps) {
                   <FormItem>
                     <FormLabel htmlFor="title">Title</FormLabel>
                     <FormControl>
-                      <Input id="title" disabled={event.title.startsWith("Lec-") || event.title.startsWith("Tut-") || event.title.startsWith("Prc-")} placeholder="Event title" data-invalid={fieldState.invalid} {...field} />
+                      <Input id="title" disabled={event.title.startsWith("Lec-") || event.title.startsWith("Tut-") || event.title.startsWith("Prc-")} placeholder="Event title" maxLength={50} data-invalid={fieldState.invalid} {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/calendar/components/dialogs/edit-event-dialog.tsx
+++ b/calendar/components/dialogs/edit-event-dialog.tsx
@@ -306,7 +306,10 @@ export function EditEventDialog({ children, event }: IProps) {
                         <SingleDayPicker
                           id="startDate"
                           value={field.value}
-                          onSelect={date => field.onChange(date as Date)}
+                          onSelect={date => {
+                            field.onChange(date as Date);
+                            form.trigger(["startTime", "endTime", "startDate", "endDate", "recurrenceEndDate"]);
+                          }}
                           placeholder="Select a date"
                           data-invalid={fieldState.invalid}
                         />
@@ -323,7 +326,10 @@ export function EditEventDialog({ children, event }: IProps) {
                     <FormItem className="flex-1">
                       <FormLabel>Start Time</FormLabel>
                       <FormControl>
-                        <TimeInput value={field.value as TimeValue} onChange={field.onChange} hourCycle={12} data-invalid={fieldState.invalid} />
+                        <TimeInput value={field.value as TimeValue} onChange={time => {
+                          field.onChange(time);
+                          form.trigger(["startTime", "endTime", "startDate", "endDate", "recurrenceEndDate"]);
+                        }} hourCycle={12} data-invalid={fieldState.invalid} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -341,7 +347,10 @@ export function EditEventDialog({ children, event }: IProps) {
                       <FormControl>
                         <SingleDayPicker
                           value={field.value}
-                          onSelect={date => field.onChange(date as Date)}
+                          onSelect={date => {
+                            field.onChange(date as Date);
+                            form.trigger(["startTime", "endTime", "startDate", "endDate", "recurrenceEndDate"]);
+                          }}
                           placeholder="Select a date"
                           data-invalid={fieldState.invalid}
                         />
@@ -358,7 +367,10 @@ export function EditEventDialog({ children, event }: IProps) {
                     <FormItem className="flex-1">
                       <FormLabel>End Time</FormLabel>
                       <FormControl>
-                        <TimeInput value={field.value as TimeValue} onChange={field.onChange} hourCycle={12} data-invalid={fieldState.invalid} />
+                        <TimeInput value={field.value as TimeValue} onChange={time => {
+                          field.onChange(time);
+                          form.trigger(["startTime", "endTime", "startDate", "endDate", "recurrenceEndDate"]);
+                        }} hourCycle={12} data-invalid={fieldState.invalid} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -438,7 +450,10 @@ export function EditEventDialog({ children, event }: IProps) {
                           <FormControl>
                             <SingleDayPicker
                               value={field.value ?? undefined}
-                              onSelect={date => field.onChange(date as Date)}
+                              onSelect={date => {
+                                field.onChange(date as Date);
+                                form.trigger(["startTime", "endTime", "startDate", "endDate", "recurrenceEndDate"]);
+                              }}
                               placeholder="No end date (forever)"
                               data-invalid={fieldState.invalid}
                             />

--- a/calendar/requests.ts
+++ b/calendar/requests.ts
@@ -47,11 +47,8 @@ function noticeToEvent(notice: NoticeFromAPI, index: number): IEvent | null {
   //const start = new Date(notice.eventTime);
   //const end = new Date(notice.eventEndTime);
 
-  const cleanStartTime = notice.eventTime.replace(/(Z|[+-]\d{2}:?\d{2})$/, '');
-  const cleanEndTime = notice.eventEndTime.replace(/(Z|[+-]\d{2}:?\d{2})$/, '');
-
-  const start = new Date(cleanStartTime);
-  const end = new Date(cleanEndTime);
+  const start = new Date(notice.eventTime);
+  const end = new Date(notice.eventEndTime || notice.eventTime);
 
   // Skip notices with invalid dates
   if (isNaN(start.getTime()) || start.getFullYear() < 1970) {

--- a/calendar/requests.ts
+++ b/calendar/requests.ts
@@ -54,13 +54,13 @@ function noticeToEvent(notice: NoticeFromAPI, index: number): IEvent | null {
   const end = new Date(cleanEndTime);
 
   // Skip notices with invalid dates
-  if (isNaN(start.getTime())) {
+  if (isNaN(start.getTime()) || start.getFullYear() < 1970) {
     console.warn("Invalid date in notice:", notice.title, notice.eventTime);
     return null;
   }
 
   // If end date is invalid, default to start date + 1 hour
-  const validEnd = isNaN(end.getTime())
+  const validEnd = isNaN(end.getTime()) || end.getFullYear() < 1970
     ? new Date(start.getTime() + 60 * 60 * 1000)
     : end;
 

--- a/calendar/schemas.ts
+++ b/calendar/schemas.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const eventSchema = z.object({
   entity: z.string().optional(), // Entity organizing the event
-  title: z.string().min(1, "Title is required"),
+  title: z.string().min(1, "Title is required").max(50, "Title must be 50 characters or less"),
   description: z.string().min(1, "Description is required"),
   startDate: z.date({ error: "Start date is required" }),
   startTime: z.object(

--- a/calendar/schemas.user-event.ts
+++ b/calendar/schemas.user-event.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
  * Kept separate so the original eventSchema is never modified.
  */
 export const userEventSchema = z.object({
-  title: z.string().min(1, "Title is required"),
+  title: z.string().min(1, "Title is required").max(50, "Title must be 50 characters or less"),
   description: z.string().default(""),
   startDate: z.date({ error: "Start date is required" }),
   startTime: z.object(

--- a/components/AddLocationDrawer.tsx
+++ b/components/AddLocationDrawer.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useHistoryBack } from "@/app/hooks/use-history-back";
+
 import {
   Drawer,
   DrawerContent,
@@ -60,6 +62,9 @@ export default function AddLocationDrawer({
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  // Close drawer on phone back button instead of navigating away
+  useHistoryBack(open, () => onOpenChange(false));
 
   // Auto-fill lat/lon + trigger open
   useEffect(() => {

--- a/server/maps/handler.adminActions.go
+++ b/server/maps/handler.adminActions.go
@@ -182,6 +182,11 @@ func addNotice(c *gin.Context) {
 		return
 	}
 
+	if !input.EventEndTime.IsZero() && input.EventEndTime.Before(input.EventTime) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Event end time cannot be before start time"})
+		return
+	}
+
 	userID, exist := c.Get("userID") // means api requests must be authenticated
 	if !exist {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
@@ -429,10 +434,15 @@ func editNotice(c *gin.Context) {
 		return
 	}
 
-	var input model.Notice
+	var input AddNoticeRequest
 	if err := c.ShouldBindJSON(&input); err != nil {
 		logrus.WithError(err).Warn("JSON binding failed")
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request format"})
+		return
+	}
+
+	if !input.EventEndTime.IsZero() && input.EventEndTime.Before(input.EventTime) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Event end time cannot be before start time"})
 		return
 	}
 

--- a/server/maps/handler.userEvents.go
+++ b/server/maps/handler.userEvents.go
@@ -52,6 +52,11 @@ func createUserEvent(c *gin.Context) {
 		return
 	}
 
+	if !input.EventEndTime.IsZero() && input.EventEndTime.Before(input.EventTime) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Event end time cannot be before start time"})
+		return
+	}
+
 	color := input.Color
 	if color == "" {
 		color = "blue"
@@ -121,6 +126,11 @@ func updateUserEvent(c *gin.Context) {
 	if err := c.ShouldBindJSON(&input); err != nil {
 		logrus.WithError(err).Warn("JSON binding failed for user event update")
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request format"})
+		return
+	}
+
+	if !input.EventEndTime.IsZero() && input.EventEndTime.Before(input.EventTime) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Event end time cannot be before start time"})
 		return
 	}
 

--- a/server/maps/request.model.go
+++ b/server/maps/request.model.go
@@ -33,7 +33,7 @@ func (r AddLocationRequest) ToLocation(userID uuid.UUID) model.Location {
 }
 
 type AddNoticeRequest struct {
-	Title        string     `json:"title" binding:"required"`
+	Title        string     `json:"title" binding:"required,max=50"`
 	Description  string     `json:"description" binding:"required"`
 	Body         string     `json:"body"`
 	CoverPic     *uuid.UUID `json:"coverPic"`
@@ -67,7 +67,7 @@ type FlagActionRequest struct {
 }
 
 type AddUserEventRequest struct {
-	Title                string     `json:"title" binding:"required"`
+	Title                string     `json:"title" binding:"required,max=50"`
 	Description          string     `json:"description"`
 	EventTime            time.Time  `json:"eventTime" binding:"required"`
 	EventEndTime         time.Time  `json:"eventEndTime" binding:"required"`


### PR DESCRIPTION
## Summary by Sourcery

Enforce stricter validation and UX safeguards for event notices, calendar events, and location drawers/modals, including title length limits, date consistency checks, and improved mobile back-button behavior.

New Features:
- Intercept the browser or device back button via a reusable hook to close drawers and modals instead of navigating away on mobile.

Bug Fixes:
- Prevent creating or editing notices and user events where the event end time is before the start time on both client and server.
- Ignore invalid or pre-1970 event dates when converting notices into calendar events, and default invalid end times to a reasonable value.
- Avoid submitting malformed notice payloads by explicitly mapping form fields and guarding against invalid ISO date conversions.

Enhancements:
- Limit event and notice titles to 50 characters with corresponding validation in both frontend forms and backend request binding.
- Trigger calendar form re-validation when start/end dates or times change to ensure date/time constraints are kept in sync.
- Show a live character count for notice titles and cap their length in the admin publish form.