### PR TITLE
Improve image upload validation and add image bomb protection

### DIFF
--- a/server/assets/handler.go
+++ b/server/assets/handler.go
@@ -16,6 +16,7 @@ import (
 )
 
 func uploadAsset(c *gin.Context) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, 10<<20) // 10MB hard cap
 	var req ImageUploadRequest
 	if err := c.ShouldBind(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Image is required"})

--- a/server/assets/utils.go
+++ b/server/assets/utils.go
@@ -44,6 +44,15 @@ func ProcessImageBytes(imgBytes []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read image metadata: %w", err)
 	}
+
+	if metadata.Size.Width > 8000 || metadata.Size.Height > 8000 {
+    return nil, fmt.Errorf(
+        "image dimensions too large: %dx%d",
+        metadata.Size.Width,
+        metadata.Size.Height,
+    )
+	}
+	
 	if err := validateImageMetadata(metadata); err != nil {
 		return nil, err
 	}
@@ -55,7 +64,7 @@ func ProcessImageBytes(imgBytes []byte) ([]byte, error) {
 		// Height:  payload.Height,
 	}
 	// Image format converter
-
+	
 	newImage := bimg.NewImage(imgBytes)
 	imgType := newImage.Type()
 

--- a/server/auth/handler.profilepic.go
+++ b/server/auth/handler.profilepic.go
@@ -14,6 +14,8 @@ import (
 )
 
 func UploadProfileImage(c *gin.Context) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, 10<<20) // 10MB hard cap
+	
 	userIDRaw, exists := c.Get("userID")
 	if !exists {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})


### PR DESCRIPTION
This PR enhances image upload handling by:
- Increasing the upload size limit to 10 MB.
- Adding image dimension validation to prevent image bomb attacks.
- Improving the overall reliability and security of image processing.

## Summary by Sourcery

Enforce stricter validation and limits for uploaded images to improve security and reliability.

Bug Fixes:
- Reject images with excessively large dimensions to mitigate image bomb-style attacks.

Enhancements:
- Increase server-side upload request body limit for profile and asset images to 10 MB.