### PR TITLE
 reviews bounded in backend

### DIFF
--- a/server/workers/review_moderation.go
+++ b/server/workers/review_moderation.go
@@ -73,6 +73,13 @@ func ApproveReviewRecord(reviewID uuid.UUID) (bool, error) {
 			return nil // Return nil so the transaction doesn't fail, we just exit it early
 		}
 
+		if review.Rating < 1 || review.Rating > 5 {
+			logrus.Errorf("Review %s has out-of-range rating %d; rejecting instead of approving", review.ReviewId, review.Rating)
+			return tx.Model(&model.Review{}).
+				Where("review_id = ?", reviewID).
+				Update("status", model.RejectedByBot).Error
+		}
+
 		if err := tx.Model(&model.Review{}).
 			Where("review_id = ?", reviewID).
 			Update("status", model.Approved).Error; err != nil {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent reviews with ratings outside the 1–5 range from being approved by the moderation worker and mark them as bot-rejected instead.