### PR TITLE
Add: Stateful Refresh Tokens

### DIFF
--- a/components/BottomNavbar.tsx
+++ b/components/BottomNavbar.tsx
@@ -26,7 +26,7 @@ export function BottomNav() {
   ) => {
     e?.preventDefault();
 
-    if (label === "Location") {
+    if (label === "Add Location") {
       if (isGlobalLoading) return;
 
       if (!isLoggedIn) {

--- a/server/auth/handler.login.go
+++ b/server/auth/handler.login.go
@@ -88,9 +88,12 @@ func loginHandler(c *gin.Context) {
 		return
 	}
 
-	// Creating JWT token
 	accessToken, err := middleware.GenerateAccessToken(dbUser.UserID)
-	refreshToken, err := middleware.GenerateRefreshToken(dbUser.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token"})
+		return
+	}
+	refreshToken, err := middleware.IssueRefreshToken(dbUser.UserID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token"})
 		return

--- a/server/auth/handler.logout.go
+++ b/server/auth/handler.logout.go
@@ -8,6 +8,6 @@ import (
 )
 
 func logoutHandler(c *gin.Context) {
-	middleware.ClearAuthCookie(c)
+	middleware.RevokeSession(c)
 	c.JSON(http.StatusOK, gin.H{"message": "Logged Out Successfully"})
 }

--- a/server/auth/handler.verify.go
+++ b/server/auth/handler.verify.go
@@ -64,10 +64,13 @@ func verificationHandler(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Request Failed, Please try again later"})
 		return
 	}
-	accessToken, err := middleware.GenerateAccessToken(user.UserID);
-	refreshToken, err := middleware.GenerateRefreshToken(user.UserID);
+	accessToken, err := middleware.GenerateAccessToken(user.UserID)
 	if err != nil {
-		// TODO: Redirect to login page
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token, you will need to login!"})
+		return
+	}
+	refreshToken, err := middleware.IssueRefreshToken(user.UserID)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token, you will need to login!"})
 		return
 	}

--- a/server/connections/db.go
+++ b/server/connections/db.go
@@ -34,6 +34,7 @@ func dbConnection() {
 
 	models := []interface{}{
 		&model.User{},
+		&model.UserRefreshToken{},
 		&model.Location{},
 		&model.Notice{},
 		&model.Review{},

--- a/server/middleware/authenticator.go
+++ b/server/middleware/authenticator.go
@@ -61,6 +61,10 @@ func UserAuthenticator(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid token claims"})
 		return
 	}
+	if claims.TokenType != "access" {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid token type"})
+		return
+	}
 	// Set the role here
 	// TODO: Find better way, here whenever i extract i need to do a check if that thing exist or not
 	c.Set("userID", claims.UserID)
@@ -98,6 +102,10 @@ func tryRefresh(c *gin.Context) {
 	claims, ok := token.Claims.(*JWTClaimsRefresh)
 	if !ok || !token.Valid {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid token claims"})
+		return
+	}
+	if claims.TokenType != "refresh" {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid token type"})
 		return
 	}
 

--- a/server/middleware/authenticator.go
+++ b/server/middleware/authenticator.go
@@ -107,6 +107,12 @@ func tryRefresh(c *gin.Context) {
 		return
 	}
 
+	storedUserID, err := IsRefreshTokenActive(refreshToken)
+	if err != nil || storedUserID != userID {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Session revoked"})
+		return
+	}
+
 	// Fetch user details from db
 
 	var modelUser model.User

--- a/server/middleware/model.go
+++ b/server/middleware/model.go
@@ -19,12 +19,40 @@ type JWTClaims struct {
 	jwt.RegisteredClaims
 }
 
+func NewAccessTokenClaims(userID uuid.UUID, role int, verified bool, visibility bool) JWTClaims {
+	return JWTClaims{
+		UserID:     userID,
+		Role:       role,
+		Verified:   verified,
+		Visibility: visibility,
+		TokenType:  "access",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   userID.String(),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+			Issuer:    "pclub",
+		},
+	}
+}
+
 type JWTClaimsRefresh struct {
 	UserID    string `json:"user_id"`
 	TokenType string `json:"token_type"`
 	jwt.RegisteredClaims
 }
 
+func NewRefreshTokenClaims(userID uuid.UUID, expiry time.Duration) JWTClaimsRefresh {
+	return JWTClaimsRefresh{
+		UserID:    userID.String(),
+		TokenType: "refresh",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   userID.String(),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(expiry)),
+			Issuer:    "pclub",
+		},
+	}
+}
 
 // AuthConfig holds authentication configuration
 type AuthConfig struct {

--- a/server/middleware/model.go
+++ b/server/middleware/model.go
@@ -10,27 +10,29 @@ import (
 
 // JWTClaims custom claims structure
 type JWTClaims struct {
-	UserID   uuid.UUID `json:"user_id"`
-	RollNo   string    `json:"roll_no"`
-	Role     int       `json:"role"`
-	Verified bool      `json:"verified"`
-	Visibility bool    `json:"visibility"`
+	UserID     uuid.UUID `json:"user_id"`
+	RollNo     string    `json:"roll_no"`
+	Role       int       `json:"role"`
+	Verified   bool      `json:"verified"`
+	Visibility bool      `json:"visibility"`
+	TokenType  string    `json:"token_type"`
 	jwt.RegisteredClaims
 }
 
 type JWTClaimsRefresh struct {
-	UserID string `json:"user_id"`
+	UserID    string `json:"user_id"`
+	TokenType string `json:"token_type"`
 	jwt.RegisteredClaims
 }
 
 
 // AuthConfig holds authentication configuration
 type AuthConfig struct {
-	JWTSecretKey    string
-	TokenExpiration time.Duration
+	JWTSecretKey       string
+	TokenExpiration    time.Duration
 	RefreshTokenExpiry time.Duration
-	CookieDomain    string
-	CookieSecure    bool
-	CookieHTTPOnly  bool
-	SameSiteMode    http.SameSite
+	CookieDomain       string
+	CookieSecure       bool
+	CookieHTTPOnly     bool
+	SameSiteMode       http.SameSite
 }

--- a/server/middleware/token.go
+++ b/server/middleware/token.go
@@ -31,6 +31,7 @@ func SaveRefreshToken(userID uuid.UUID, token string) error {
 		UserID:    userID,
 		Token:     token,
 		ExpiresAt: time.Now().Add(authConfig.RefreshTokenExpiry),
+		IsActive:  true,
 	}).Error
 }
 
@@ -38,13 +39,15 @@ func RevokeRefreshToken(token string) error {
 	if token == "" {
 		return nil
 	}
-	return connections.DB.Where("token = ?", token).Delete(&model.UserRefreshToken{}).Error
+	return connections.DB.Model(&model.UserRefreshToken{}).
+		Where("token = ?", token).
+		Update("is_active", false).Error
 }
 
 func IsRefreshTokenActive(token string) (uuid.UUID, error) {
 	var session model.UserRefreshToken
 	err := connections.DB.
-		Where("token = ? AND expires_at > ?", token, time.Now()).
+		Where("token = ? AND expires_at > ? AND is_active = ?", token, time.Now(), true).
 		First(&session).Error
 	if err != nil {
 		return uuid.Nil, err

--- a/server/middleware/token.go
+++ b/server/middleware/token.go
@@ -3,6 +3,8 @@ package middleware
 import (
 	"compass/connections"
 	"compass/model"
+	"crypto/sha256"
+	"encoding/hex"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -18,10 +20,15 @@ func GenerateRefreshToken(userID uuid.UUID) (string, error) {
 	return token.SignedString([]byte(authConfig.JWTSecretKey))
 }
 
+func hashRefreshToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
 func SaveRefreshToken(userID uuid.UUID, token string) error {
 	return connections.DB.Create(&model.UserRefreshToken{
 		UserID:    userID,
-		Token:     token,
+		Token:     hashRefreshToken(token),
 		ExpiresAt: time.Now().Add(authConfig.RefreshTokenExpiry),
 	}).Error
 }
@@ -31,14 +38,14 @@ func RevokeRefreshToken(token string) error {
 		return nil
 	}
 	return connections.DB.Model(&model.UserRefreshToken{}).
-		Where("token = ?", token).
+		Where("token = ?", hashRefreshToken(token)).
 		Update("is_active", false).Error
 }
 
 func IsRefreshTokenActive(token string) (uuid.UUID, error) {
 	var session model.UserRefreshToken
 	err := connections.DB.
-		Where("token = ? AND expires_at > ? AND is_active = ?", token, time.Now(), true).
+		Where("token = ? AND expires_at > ? AND is_active = ?", hashRefreshToken(token), time.Now(), true).
 		First(&session).Error
 	if err != nil {
 		return uuid.Nil, err

--- a/server/middleware/token.go
+++ b/server/middleware/token.go
@@ -12,15 +12,7 @@ import (
 )
 
 func GenerateRefreshToken(userID uuid.UUID) (string, error) {
-	claims := JWTClaimsRefresh{
-		UserID: userID.String(),
-		RegisteredClaims: jwt.RegisteredClaims{
-			Subject:   userID.String(),
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(authConfig.RefreshTokenExpiry)),
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
-			Issuer:    "pclub",
-		},
-	}
+	claims := NewRefreshTokenClaims(userID, authConfig.RefreshTokenExpiry)
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString([]byte(authConfig.JWTSecretKey))
@@ -38,13 +30,15 @@ func RevokeRefreshToken(token string) error {
 	if token == "" {
 		return nil
 	}
-	return connections.DB.Where("token = ?", token).Delete(&model.UserRefreshToken{}).Error
+	return connections.DB.Model(&model.UserRefreshToken{}).
+		Where("token = ?", token).
+		Update("is_active", false).Error
 }
 
 func IsRefreshTokenActive(token string) (uuid.UUID, error) {
 	var session model.UserRefreshToken
 	err := connections.DB.
-		Where("token = ? AND expires_at > ?", token, time.Now()).
+		Where("token = ? AND expires_at > ? AND is_active = ?", token, time.Now(), true).
 		First(&session).Error
 	if err != nil {
 		return uuid.Nil, err
@@ -91,19 +85,8 @@ func GenerateAccessToken(userID uuid.UUID) (string, error) {
 	verified := modelUser.IsVerified
 	visibility := modelUser.Profile.Visibility
 
-	claims := JWTClaims{
-		UserID:     userID,
-		RollNo:     modelUser.Profile.RollNo,
-		Role:       role,
-		Verified:   verified,
-		Visibility: visibility,
-		RegisteredClaims: jwt.RegisteredClaims{
-			Subject:   userID.String(),
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(authConfig.TokenExpiration)),
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
-			Issuer:    "pclub",
-		},
-	}
+	claims := NewAccessTokenClaims(userID, role, verified, visibility)
+	claims.RollNo = modelUser.Profile.RollNo
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString([]byte(authConfig.JWTSecretKey))
 }

--- a/server/middleware/token.go
+++ b/server/middleware/token.go
@@ -31,7 +31,6 @@ func SaveRefreshToken(userID uuid.UUID, token string) error {
 		UserID:    userID,
 		Token:     token,
 		ExpiresAt: time.Now().Add(authConfig.RefreshTokenExpiry),
-		IsActive:  true,
 	}).Error
 }
 
@@ -39,15 +38,13 @@ func RevokeRefreshToken(token string) error {
 	if token == "" {
 		return nil
 	}
-	return connections.DB.Model(&model.UserRefreshToken{}).
-		Where("token = ?", token).
-		Update("is_active", false).Error
+	return connections.DB.Where("token = ?", token).Delete(&model.UserRefreshToken{}).Error
 }
 
 func IsRefreshTokenActive(token string) (uuid.UUID, error) {
 	var session model.UserRefreshToken
 	err := connections.DB.
-		Where("token = ? AND expires_at > ? AND is_active = ?", token, time.Now(), true).
+		Where("token = ? AND expires_at > ?", token, time.Now()).
 		First(&session).Error
 	if err != nil {
 		return uuid.Nil, err

--- a/server/middleware/token.go
+++ b/server/middleware/token.go
@@ -26,6 +26,50 @@ func GenerateRefreshToken(userID uuid.UUID) (string, error) {
 	return token.SignedString([]byte(authConfig.JWTSecretKey))
 }
 
+func SaveRefreshToken(userID uuid.UUID, token string) error {
+	return connections.DB.Create(&model.UserRefreshToken{
+		UserID:    userID,
+		Token:     token,
+		ExpiresAt: time.Now().Add(authConfig.RefreshTokenExpiry),
+	}).Error
+}
+
+func RevokeRefreshToken(token string) error {
+	if token == "" {
+		return nil
+	}
+	return connections.DB.Where("token = ?", token).Delete(&model.UserRefreshToken{}).Error
+}
+
+func IsRefreshTokenActive(token string) (uuid.UUID, error) {
+	var session model.UserRefreshToken
+	err := connections.DB.
+		Where("token = ? AND expires_at > ?", token, time.Now()).
+		First(&session).Error
+	if err != nil {
+		return uuid.Nil, err
+	}
+	return session.UserID, nil
+}
+
+func IssueRefreshToken(userID uuid.UUID) (string, error) {
+	token, err := GenerateRefreshToken(userID)
+	if err != nil {
+		return "", err
+	}
+	if err := SaveRefreshToken(userID, token); err != nil {
+		return "", err
+	}
+	return token, nil
+}
+
+func RevokeSession(c *gin.Context) {
+	if refreshToken, err := c.Cookie("refresh_token"); err == nil {
+		_ = RevokeRefreshToken(refreshToken)
+	}
+	ClearAuthCookie(c)
+}
+
 func GenerateAccessToken(userID uuid.UUID) (string, error) {
 
 	var modelUser model.User

--- a/server/model/userSession.go
+++ b/server/model/userSession.go
@@ -11,5 +11,6 @@ type UserRefreshToken struct {
 	UserID    uuid.UUID `gorm:"type:uuid;index;not null"`
 	Token     string    `gorm:"type:text;uniqueIndex;not null"`
 	ExpiresAt time.Time `gorm:"index;not null"`
+	IsActive  bool      `gorm:"default:true;not null"`
 	CreatedAt time.Time
 }

--- a/server/model/userSession.go
+++ b/server/model/userSession.go
@@ -1,0 +1,15 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type UserRefreshToken struct {
+	ID        uuid.UUID `gorm:"type:uuid;default:gen_random_uuid();primaryKey"`
+	UserID    uuid.UUID `gorm:"type:uuid;index;not null"`
+	Token     string    `gorm:"type:text;uniqueIndex;not null"`
+	ExpiresAt time.Time `gorm:"index;not null"`
+	CreatedAt time.Time
+}

--- a/server/search/handler.userAction.go
+++ b/server/search/handler.userAction.go
@@ -191,15 +191,22 @@ func toggleVisibility(c *gin.Context) {
 	}
 
 	// TODO: We can extract out this token refresh logic
-	// Clear the old cookie with visibility true
+	if currentRefresh, err := c.Cookie("refresh_token"); err == nil {
+		_ = middleware.RevokeRefreshToken(currentRefresh)
+	}
 	middleware.ClearAuthCookie(c)
 	token, err := middleware.GenerateAccessToken(userID.(uuid.UUID))
-	ref_token, _ := middleware.GenerateRefreshToken(userID.(uuid.UUID))
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{"message": "visibility updated successfully, please login again to continue"})
+		return
+	}
+	refToken, err := middleware.IssueRefreshToken(userID.(uuid.UUID))
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"message": "visibility updated successfully, please login again to continue"})
+		return
 	}
 	middleware.SetAuthCookie(c, token)
-	middleware.SetRefreshCookie(c, ref_token)
+	middleware.SetRefreshCookie(c, refToken)
 
 	c.JSON(http.StatusOK, gin.H{"message": "visibility updated successfully"})
 


### PR DESCRIPTION
- Add a new table user_refresh_tokens which stores a refresh token every time a user logs.
- By default the refresh token is active and it is set to inactive when the user logs out

## Summary by Sourcery

Implement stateful, revocable refresh tokens backed by the database, update authentication flows to distinguish access vs refresh tokens, and adjust logout and user actions to manage refresh token lifecycle.

New Features:
- Persist user refresh tokens in a new UserRefreshToken table with hashed tokens, expiry, and active status for stateful session management

Enhancements:
- Introduce token_type claims for access and refresh tokens and enforce type checks in authentication and refresh flows
- Track and revoke refresh tokens on logout, visibility changes, and refresh attempts to support session revocation
- Refactor access and refresh token generation into helper constructors and an IssueRefreshToken flow for consistency and safety

Build:
- Include UserRefreshToken model in database migrations

Chores:
- Rename bottom navigation label from "Location" to "Add Location" for clearer UI messaging