### PR TITLE
fix: improvements and bugs

### DIFF
--- a/components/BottomNavbar.tsx
+++ b/components/BottomNavbar.tsx
@@ -26,7 +26,7 @@ export function BottomNav() {
   ) => {
     e?.preventDefault();
 
-    if (label === "Location") {
+    if (label === "Add Location") {
       if (isGlobalLoading) return;
 
       if (!isLoggedIn) {

--- a/components/ContextProvider.tsx
+++ b/components/ContextProvider.tsx
@@ -36,6 +36,51 @@ export function GlobalContextProvider({ children }: { children: ReactNode }) {
   const [isAdmin, setAdmin] = useState<boolean>(false);
 
   useEffect(() => {
+
+    // Patch fetch globally to include CSRF token on state-changing requests
+    if (typeof window !== "undefined" && !(window as any).__fetchPatched) {
+      const originalFetch = window.fetch;
+      const STATE_CHANGING_METHODS = ["POST", "PUT", "DELETE", "PATCH"];
+
+      window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : undefined;
+
+        const method = (init?.method || request?.method || "GET").toUpperCase();
+
+        if (STATE_CHANGING_METHODS.includes(method)) {
+          const csrfToken =
+            document.cookie
+              .split("; ")
+              .find((row) => row.startsWith("csrf_token="))
+              ?.split("=")[1] || "";
+
+          if (csrfToken) {
+            // Merge headers from the original Request (if any) and init.headers
+            const mergedHeaders = new Headers(request?.headers || undefined);
+
+            if (init?.headers) {
+              new Headers(init.headers).forEach((value, key) => {
+                mergedHeaders.set(key, value);
+              });
+            }
+
+            mergedHeaders.set("X-CSRF-Token", csrfToken);
+
+            init = {
+              ...init,
+              headers: mergedHeaders,
+              method, // ensure the normalized method is preserved
+            };
+          }
+        }
+
+        return originalFetch(input as any, init);
+      };
+
+      (window as any).__fetchPatched = true;
+    }
+
+    
     async function verifyingLogin() {
       try {
         const response = await fetch(

--- a/nginx.conf
+++ b/nginx.conf
@@ -34,6 +34,7 @@ http {
         # FIXME(prod): Change to correct path. 
         ssl_certificate /Users/Shared/Deploy/codebase/compass-assets/certs/cert.pem;
         ssl_certificate_key /Users/Shared/Deploy/codebase/compass-assets/certs/key.pem;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.tile.openstreetmap.org; connect-src 'self' https://basemaps.cartocdn.com; worker-src 'self' blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;" always;
 
 
         # Location for the main (compass) frontend, opens up profile page at root.
@@ -87,6 +88,9 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_hide_header Cache-Control;
+            add_header Cache-Control "private, max-age=14400" always;
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.tile.openstreetmap.org; connect-src 'self' https://basemaps.cartocdn.com; worker-src 'self' blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;" always;
         }
 
         # Location for the API server of student search

--- a/search/src/components/ContextProvider.tsx
+++ b/search/src/components/ContextProvider.tsx
@@ -300,33 +300,49 @@ export function GlobalContextProvider({ children }: { children: ReactNode }) {
   };
 
   useEffect(() => {
-
     // Patch fetch globally to include CSRF token on state-changing requests
     if (typeof window !== "undefined" && !(window as any).__fetchPatched) {
       const originalFetch = window.fetch;
-      window.fetch = async (input, init) => {
-        const method = (init?.method || "GET").toUpperCase();
-        if (["POST", "PUT", "DELETE", "PATCH"].includes(method)) {
-          const csrfToken = document.cookie
-            .split("; ")
-            .find((row) => row.startsWith("csrf_token="))
-            ?.split("=")[1] || "";
+      const STATE_CHANGING_METHODS = ["POST", "PUT", "DELETE", "PATCH"];
+
+      window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : undefined;
+
+        const method = (init?.method || request?.method || "GET").toUpperCase();
+
+        if (STATE_CHANGING_METHODS.includes(method)) {
+          const csrfToken =
+            document.cookie
+              .split("; ")
+              .find((row) => row.startsWith("csrf_token="))
+              ?.split("=")[1] || "";
+
           if (csrfToken) {
+            // Merge headers from the original Request (if any) and init.headers
+            const mergedHeaders = new Headers(request?.headers || undefined);
+
+            if (init?.headers) {
+              new Headers(init.headers).forEach((value, key) => {
+                mergedHeaders.set(key, value);
+              });
+            }
+
+            mergedHeaders.set("X-CSRF-Token", csrfToken);
+
             init = {
               ...init,
-              headers: {
-                ...init?.headers,
-                "X-CSRF-Token": csrfToken,
-              },
+              headers: mergedHeaders,
+              method, // ensure the normalized method is preserved
             };
           }
         }
-        return originalFetch(input, init);
+
+        return originalFetch(input as any, init);
       };
+
       (window as any).__fetchPatched = true;
     }
 
-    
     async function verifyingLogin() {
       try {
         setGlobalLoading(true);

--- a/search/src/components/ContextProvider.tsx
+++ b/search/src/components/ContextProvider.tsx
@@ -300,6 +300,33 @@ export function GlobalContextProvider({ children }: { children: ReactNode }) {
   };
 
   useEffect(() => {
+
+    // Patch fetch globally to include CSRF token on state-changing requests
+    if (typeof window !== "undefined" && !(window as any).__fetchPatched) {
+      const originalFetch = window.fetch;
+      window.fetch = async (input, init) => {
+        const method = (init?.method || "GET").toUpperCase();
+        if (["POST", "PUT", "DELETE", "PATCH"].includes(method)) {
+          const csrfToken = document.cookie
+            .split("; ")
+            .find((row) => row.startsWith("csrf_token="))
+            ?.split("=")[1] || "";
+          if (csrfToken) {
+            init = {
+              ...init,
+              headers: {
+                ...init?.headers,
+                "X-CSRF-Token": csrfToken,
+              },
+            };
+          }
+        }
+        return originalFetch(input, init);
+      };
+      (window as any).__fetchPatched = true;
+    }
+
+    
     async function verifyingLogin() {
       try {
         setGlobalLoading(true);

--- a/server/auth/handler.login.go
+++ b/server/auth/handler.login.go
@@ -90,6 +90,10 @@ func loginHandler(c *gin.Context) {
 
 	// Creating JWT token
 	accessToken, err := middleware.GenerateAccessToken(dbUser.UserID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token"})
+		return
+	}
 	refreshToken, err := middleware.GenerateRefreshToken(dbUser.UserID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token"})

--- a/server/auth/handler.signup.go
+++ b/server/auth/handler.signup.go
@@ -87,7 +87,49 @@ func signupHandler(c *gin.Context) {
 		// Handle Duplicate User Error (Postgres Code 23505)
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			c.JSON(http.StatusConflict, gin.H{"error": "User already exists"})
+			var existingUser model.User
+			if err := connections.DB.Where("email = ?", strings.ToLower(input.Email)).First(&existingUser).Error; err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Database error"})
+				return
+			}
+			if existingUser.IsVerified {
+				c.JSON(http.StatusConflict, gin.H{"error": "User already exists"})
+				return
+			}
+
+			// Generate new token and update user
+			newToken := generateVerificationToken()
+			newExpiry := time.Now().Add(time.Duration(viper.GetInt("expiry.emailVerification")) * time.Hour).Format(time.RFC3339)
+			newVerificationToken := fmt.Sprintf("%s<>%s", newToken, newExpiry)
+
+			if err := connections.DB.Model(&existingUser).Update("verification_token", newVerificationToken).Error; err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update verification token"})
+				return
+			}
+
+			// Dispatch mail job
+			verifyLink := fmt.Sprintf("%s/signup?token=%s&userID=%s",
+				viper.GetString("frontend_url"),
+				newToken,
+				existingUser.UserID)
+
+			job := workers.MailJob{
+				Type: "user_verification",
+				To:   input.Email,
+				Data: map[string]interface{}{
+					"token": fmt.Sprintf("%s-%s", newToken[:3], newToken[3:]),
+					"link":  verifyLink,
+				},
+			}
+			payload, _ := json.Marshal(job)
+			if err := workers.PublishJob(payload, model.MailQueue); err != nil {
+				logrus.Error("Failed to enqueue mail job:", err)
+			}
+
+			c.JSON(http.StatusOK, gin.H{
+				"message": "Verification email resent. Please check your email.",
+				"userID":  existingUser.UserID,
+			})
 			return
 		}
 		// Handle other DB errors

--- a/server/auth/handler.verify.go
+++ b/server/auth/handler.verify.go
@@ -83,7 +83,7 @@ func verificationHandler(c *gin.Context) {
 				if ttl > 0 {
 					c.Header("Retry-After", fmt.Sprintf("%d", int(ttl.Seconds())+1))
 				}
-				c.JSON(http.StatusTooManyRequests, gin.H{"error": "Too many incorrect attempts. Please wait 15 minutesbefore trying again."})
+				c.JSON(http.StatusTooManyRequests, gin.H{"error": "Too many incorrect attempts. Please wait 15 minutes before trying again."})
 			}
 		} else {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid OTP"})
@@ -101,6 +101,11 @@ func verificationHandler(c *gin.Context) {
 		return
 	}
 	accessToken, err := middleware.GenerateAccessToken(user.UserID)
+	if err != nil {
+		// TODO: Redirect to login page
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token, you will need to login!"})
+		return
+	}
 	refreshToken, err := middleware.GenerateRefreshToken(user.UserID)
 	if err != nil {
 		// TODO: Redirect to login page

--- a/server/auth/handler.verify.go
+++ b/server/auth/handler.verify.go
@@ -15,14 +15,13 @@ import (
 	"github.com/google/uuid"
 )
 
-
 func generateVerificationToken() string {
-    // Generate a number between 0 and 999999
-    n, err := rand.Int(rand.Reader, big.NewInt(1000000))
-    if err != nil {
-        return "" 
-    }
-    return fmt.Sprintf("%06d", n.Int64()) // always 6 digits
+	// Generate a number between 0 and 999999
+	n, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%06d", n.Int64()) // always 6 digits
 }
 
 func verificationHandler(c *gin.Context) {
@@ -33,6 +32,19 @@ func verificationHandler(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid Request"})
 		return
 	}
+
+	// Check rate limit before doing anything else
+	rateLimitKey := fmt.Sprintf("rate_limit:email_verification:%s", userID)
+	currentAttempts, redisErr := connections.RedisClient.Get(connections.RedisCtx, rateLimitKey).Int64()
+	if redisErr == nil && currentAttempts >= int64(verificationMaxAttempts) {
+		ttl, _ := connections.RedisClient.TTL(connections.RedisCtx, rateLimitKey).Result()
+		if ttl > 0 {
+			c.Header("Retry-After", fmt.Sprintf("%d", int(ttl.Seconds())+1))
+		}
+		c.JSON(http.StatusTooManyRequests, gin.H{"error": "Too many incorrect attempts. Please wait 15 minutes before trying again."})
+		return
+	}
+
 	var user model.User
 	if err := db.Where("user_id = ?", userID).First(&user).Error; err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "User not found"})
@@ -55,17 +67,41 @@ func verificationHandler(c *gin.Context) {
 		return
 	}
 	if tokenSplit[0] != token {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid OTP"})
+		// Wrong OTP — increment counter and reset the 15-min window on each wrong attempt
+		attempts, incrErr := connections.RedisClient.Incr(connections.RedisCtx, rateLimitKey).Result()
+		if incrErr == nil {
+			// Always reset expiry so the window is 15 min from the last wrong attempt
+			connections.RedisClient.Expire(connections.RedisCtx, rateLimitKey, verificationWindow)
+			remaining := int64(verificationMaxAttempts) - attempts
+			if remaining > 0 {
+				c.JSON(http.StatusUnauthorized, gin.H{
+					"error":             "Invalid OTP",
+					"attemptsRemaining": remaining,
+				})
+			} else {
+				ttl, _ := connections.RedisClient.TTL(connections.RedisCtx, rateLimitKey).Result()
+				if ttl > 0 {
+					c.Header("Retry-After", fmt.Sprintf("%d", int(ttl.Seconds())+1))
+				}
+				c.JSON(http.StatusTooManyRequests, gin.H{"error": "Too many incorrect attempts. Please wait 15 minutesbefore trying again."})
+			}
+		} else {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid OTP"})
+		}
 		return
 	}
+
+	// Correct OTP — clear the rate limit counter
+	connections.RedisClient.Del(connections.RedisCtx, rateLimitKey)
+
 	user.IsVerified = true
 	user.VerificationToken = ""
 	if db.Save(&user).Error != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Request Failed, Please try again later"})
 		return
 	}
-	accessToken, err := middleware.GenerateAccessToken(user.UserID);
-	refreshToken, err := middleware.GenerateRefreshToken(user.UserID);
+	accessToken, err := middleware.GenerateAccessToken(user.UserID)
+	refreshToken, err := middleware.GenerateRefreshToken(user.UserID)
 	if err != nil {
 		// TODO: Redirect to login page
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token, you will need to login!"})
@@ -76,6 +112,6 @@ func verificationHandler(c *gin.Context) {
 
 	// TODO: Make sure both cookies are set properly, i observed previously that only auth cookie was being set after otp verification
 	middleware.SetRefreshCookie(c, refreshToken)
-middleware.SetAuthCookie(c, accessToken)
+	middleware.SetAuthCookie(c, accessToken)
 	c.JSON(http.StatusOK, gin.H{"message": "Email verification successful."})
 }

--- a/server/auth/handler.verify.go
+++ b/server/auth/handler.verify.go
@@ -41,7 +41,14 @@ func verificationHandler(c *gin.Context) {
 		if ttl > 0 {
 			c.Header("Retry-After", fmt.Sprintf("%d", int(ttl.Seconds())+1))
 		}
-		c.JSON(http.StatusTooManyRequests, gin.H{"error": "Too many incorrect attempts. Please wait 15 minutes before trying again."})
+
+		durationMinutes := int(verificationWindow.Minutes())
+		waitMessage := fmt.Sprintf("Too many incorrect attempts. Please wait %d minute", durationMinutes)
+		if durationMinutes != 1 {
+			waitMessage += "s"
+		}
+
+		c.JSON(http.StatusTooManyRequests, gin.H{"error": waitMessage})
 		return
 	}
 
@@ -69,24 +76,27 @@ func verificationHandler(c *gin.Context) {
 	if tokenSplit[0] != token {
 		// Wrong OTP — increment counter and reset the 15-min window on each wrong attempt
 		attempts, incrErr := connections.RedisClient.Incr(connections.RedisCtx, rateLimitKey).Result()
-		if incrErr == nil {
-			// Always reset expiry so the window is 15 min from the last wrong attempt
-			connections.RedisClient.Expire(connections.RedisCtx, rateLimitKey, verificationWindow)
-			remaining := int64(verificationMaxAttempts) - attempts
-			if remaining > 0 {
-				c.JSON(http.StatusUnauthorized, gin.H{
-					"error":             "Invalid OTP",
-					"attemptsRemaining": remaining,
-				})
-			} else {
-				ttl, _ := connections.RedisClient.TTL(connections.RedisCtx, rateLimitKey).Result()
-				if ttl > 0 {
-					c.Header("Retry-After", fmt.Sprintf("%d", int(ttl.Seconds())+1))
-				}
-				c.JSON(http.StatusTooManyRequests, gin.H{"error": "Too many incorrect attempts. Please wait 15 minutes before trying again."})
-			}
+		if incrErr != nil {
+			// Fail closed: if Redis is unavailable we cannot enforce rate limiting,
+			// so reject the request entirely rather than silently allowing bypass.
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Service temporarily unavailable. Please try again later."})
+			return
+		}
+
+		// Always reset expiry so the window is 15 min from the last wrong attempt
+		connections.RedisClient.Expire(connections.RedisCtx, rateLimitKey, verificationWindow)
+		remaining := int64(verificationMaxAttempts) - attempts
+		if remaining > 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"error":             "Invalid OTP",
+				"attemptsRemaining": remaining,
+			})
 		} else {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid OTP"})
+			ttl, _ := connections.RedisClient.TTL(connections.RedisCtx, rateLimitKey).Result()
+			if ttl > 0 {
+				c.Header("Retry-After", fmt.Sprintf("%d", int(ttl.Seconds())+1))
+			}
+			c.JSON(http.StatusTooManyRequests, gin.H{"error": "Too many incorrect attempts. Please wait 15 minutes before trying again."})
 		}
 		return
 	}

--- a/server/auth/middleware.rate_limit.go
+++ b/server/auth/middleware.rate_limit.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	verificationMaxAttempts = 5
+	verificationMaxAttempts = 3
 	verificationWindow      = 15 * time.Minute
 )
 

--- a/server/auth/router.go
+++ b/server/auth/router.go
@@ -16,7 +16,7 @@ func Router(r *gin.Engine) {
 		auth.POST("/login", loginHandler)
 		auth.POST("/signup", signupHandler)
 		auth.GET("/logout", logoutHandler)
-		auth.GET("/verify", verificationRateLimit, verificationHandler)
+		auth.GET("/verify", verificationHandler)
 		auth.POST("/forgot-password", forgotPasswordHandler)
 		auth.POST("/reset-password", resetPasswordHandler)
 		// Middleware will handel not login state

--- a/server/middleware/authenticator.go
+++ b/server/middleware/authenticator.go
@@ -18,10 +18,10 @@ import (
 var authConfig = AuthConfig{
 	JWTSecretKey:       viper.GetString("jwt.secret"),
 	TokenExpiration:    5 * time.Minute,
-	RefreshTokenExpiry: 24 * 7 * time.Hour, // 7 days
+	RefreshTokenExpiry: 24 * 7 * time.Hour,        // 7 days
 	CookieDomain:       viper.GetString("domain"), // might need to set to "" in development
 	// FIXME(prod): Set this value to true in prod, else false
-	CookieSecure:       viper.GetString("env") != "dev", // Set to false in development
+	CookieSecure: viper.GetString("env") != "dev", // Set to false in development
 	// The Secure attribute is a crucial cookie configuration setting that instructs a web browser to send a cookie only over an encrypted HTTPS connection
 	CookieHTTPOnly: true, // Prevent XSS
 	SameSiteMode:   http.SameSiteLaxMode,
@@ -38,8 +38,30 @@ func init() {
 	}
 }
 
+var csrfProtectedMethods = map[string]struct{}{
+	"POST":   {},
+	"PUT":    {},
+	"DELETE": {},
+	"PATCH":  {},
+}
+
+// requiresCSRFProtection centralizes which HTTP methods require CSRF validation.
+func requiresCSRFProtection(method string) bool {
+	_, ok := csrfProtectedMethods[method]
+	return ok
+}
+
 // TODO: Extract the basic token extraction and verification out and keep just the user part
 func UserAuthenticator(c *gin.Context) {
+	if requiresCSRFProtection(c.Request.Method) {
+		csrfCookie, err := c.Cookie("csrf_token")
+		csrfHeader := c.GetHeader("X-CSRF-Token")
+		if err != nil || csrfHeader == "" || csrfCookie != csrfHeader {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "CSRF token mismatch or missing"})
+			return
+		}
+	}
+
 	// Check for cookie
 	tokenString, err := c.Cookie("auth_token")
 	if err != nil {

--- a/server/middleware/token.go
+++ b/server/middleware/token.go
@@ -75,6 +75,17 @@ func SetAuthCookie(c *gin.Context, token string) {
 		authConfig.CookieSecure,
 		authConfig.CookieHTTPOnly,
 	)
+
+	csrfToken := uuid.New().String()
+	c.SetCookie(
+		"csrf_token",
+		csrfToken,
+		int(authConfig.TokenExpiration.Seconds()),
+		"/",
+		authConfig.CookieDomain,
+		authConfig.CookieSecure,
+		false,
+	)
 }
 
 func SetRefreshCookie(c *gin.Context, token string) {
@@ -109,5 +120,14 @@ func ClearAuthCookie(c *gin.Context) {
 		authConfig.CookieDomain,
 		authConfig.CookieSecure,
 		authConfig.CookieHTTPOnly,
+	)
+	c.SetCookie(
+		"csrf_token",
+		"",
+		-1,
+		"/",
+		authConfig.CookieDomain,
+		authConfig.CookieSecure,
+		false,
 	)
 }

--- a/server/search/handler.userAction.go
+++ b/server/search/handler.userAction.go
@@ -194,9 +194,14 @@ func toggleVisibility(c *gin.Context) {
 	// Clear the old cookie with visibility true
 	middleware.ClearAuthCookie(c)
 	token, err := middleware.GenerateAccessToken(userID.(uuid.UUID))
-	ref_token, _ := middleware.GenerateRefreshToken(userID.(uuid.UUID))
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{"message": "visibility updated successfully, please login again to continue"})
+		return
+	}
+	ref_token, err := middleware.GenerateRefreshToken(userID.(uuid.UUID))
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"message": "visibility updated successfully, please login again to continue"})
+		return
 	}
 	middleware.SetAuthCookie(c, token)
 	middleware.SetRefreshCookie(c, ref_token)

--- a/server/search/handler.userAction.go
+++ b/server/search/handler.userAction.go
@@ -195,12 +195,12 @@ func toggleVisibility(c *gin.Context) {
 	middleware.ClearAuthCookie(c)
 	token, err := middleware.GenerateAccessToken(userID.(uuid.UUID))
 	if err != nil {
-		c.JSON(http.StatusOK, gin.H{"message": "visibility updated successfully, please login again to continue"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Visibility updated, but failed to refresh session. Please log in again."})
 		return
 	}
 	ref_token, err := middleware.GenerateRefreshToken(userID.(uuid.UUID))
 	if err != nil {
-		c.JSON(http.StatusOK, gin.H{"message": "visibility updated successfully, please login again to continue"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Visibility updated, but failed to refresh session. Please log in again."})
 		return
 	}
 	middleware.SetAuthCookie(c, token)


### PR DESCRIPTION
### Summary
- CSRF fixes
- cdn fixes
- implementation of rate limit (3 attempts otherwise wait for 15 minutes)

#### Files Changed
- `BottomNavbar.tsx` -> fix Add Location button bug
- `ContextProvider.tsx` -> any state change requests have csrf token header
- `handler.signup.go` -> Better Duplicate user checking and rate limits on OTP
- `middleware/` -> all rate limit on OTP

## Summary by Sourcery

Implement CSRF protection, OTP verification rate limiting, and security-related CDN/cache headers, while improving login/verification flows and a navbar interaction.

New Features:
- Add CSRF token cookie issuance on auth and enforce CSRF validation on state-changing requests via middleware and global fetch patching.
- Introduce rate limiting for email/OTP verification attempts with remaining-attempt feedback and retry-after handling.
- Allow unverified duplicate signup attempts to resend a verification email rather than failing outright.

Bug Fixes:
- Fix BottomNavbar Add Location button to trigger only on the correct label.
- Ensure access and refresh token generation errors during login, verification, and visibility toggling are handled gracefully and do not proceed with invalid tokens.
- Clear CSRF cookies when auth cookies are cleared to avoid stale tokens.

Enhancements:
- Refine OTP verification flow to reset rate limit windows on incorrect attempts and clear counters on success.
- Adjust auth cookie configuration for clarity and consistency in secure/HTTP-only settings.

Build:
- Add strict Content-Security-Policy and cache-control headers in nginx for frontend and search CDN responses.